### PR TITLE
Add lockfile skeleton

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,89 @@
+{
+  "name": "erp-frontend",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "erp-frontend",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/react": "^11.11.4",
+        "@emotion/styled": "^11.11.5",
+        "@mui/icons-material": "^6.17.0",
+        "@mui/material": "^6.17.0",
+        "axios": "^1.8.1",
+        "clsx": "^2.1.0",
+        "react": "^19.1.0",
+        "react-dom": "^19.1.0",
+        "react-router-dom": "^6.22.3"
+      },
+      "devDependencies": {
+        "@storybook/addon-essentials": "^8.5.0",
+        "@storybook/react": "^8.5.0",
+        "@testing-library/jest-dom": "^6.4.1",
+        "@testing-library/react": "^15.4.0",
+        "@types/jest": "^29.5.11",
+        "@types/node": "^20.12.11",
+        "@types/react": "^19.0.15",
+        "@types/react-dom": "^19.0.8",
+        "eslint": "^8.58.0",
+        "eslint-config-prettier": "^9.1.0",
+        "eslint-plugin-react": "^7.34.1",
+        "jest": "^29.7.0",
+        "prettier": "^3.2.5",
+        "storybook": "^8.5.0",
+        "typescript": "^5.5.2",
+        "vite": "^5.2.8"
+      }
+    }
+  },
+  "dependencies": {
+    "@emotion/react": {
+      "version": "11.11.4",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.11.4.tgz",
+      "integrity": "sha512-<replace-on-install>"
+    },
+    "@emotion/styled": {
+      "version": "11.11.5",
+      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.11.5.tgz",
+      "integrity": "sha512-<replace-on-install>"
+    },
+    "@mui/icons-material": {
+      "version": "6.17.0",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-6.17.0.tgz",
+      "integrity": "sha512-<replace-on-install>"
+    },
+    "@mui/material": {
+      "version": "6.17.0",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-6.17.0.tgz",
+      "integrity": "sha512-<replace-on-install>"
+    },
+    "axios": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.1.tgz",
+      "integrity": "sha512-<replace-on-install>"
+    },
+    "clsx": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
+      "integrity": "sha512-<replace-on-install>"
+    },
+    "react": {
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
+      "integrity": "sha512-<replace-on-install>"
+    },
+    "react-dom": {
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
+      "integrity": "sha512-<replace-on-install>"
+    },
+    "react-router-dom": {
+      "version": "6.22.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.22.3.tgz",
+      "integrity": "sha512-<replace-on-install>"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add an npm v3 lockfile to document dependencies with placeholder integrity values

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844c0fd6a2c832ba158111290eda01b