### PR TITLE
feat(theme): add corporate palette and accessibility docs

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -56,3 +56,19 @@ En este ejemplo `atoms/Button` aparece bajo la sección **atoms**. Usa la jerarq
 
 Cada propiedad expuesta por un componente debe documentarse con controles de Storybook (MDX o CSF). Así se mantiene una referencia interactiva y organizada.
 
+## Paleta de colores corporativa
+
+La interfaz usa un tema basado en Material UI. La paleta garantiza contraste suficiente y mantiene el lienzo (`canvas`) en `#fdf0d5`.
+
+| Propósito  | Hex      |
+|------------|---------|
+| Primario   | `#c1121f` |
+| Secundario | `#669bbc` |
+| Info       | `#003049` |
+| Error      | `#780000` |
+| Canvas     | `#fdf0d5` |
+
+## Accesibilidad de color
+
+Toda combinación de texto y fondo debe cumplir con el ratio mínimo de contraste **4.5:1** según las pautas [WCAG 2.2 AA](https://www.w3.org/WAI/WCAG22/). El tema define `contrastText` para cada color a fin de facilitar este cumplimiento.
+

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -3,6 +3,9 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Google+Sans:wght@400;500;700&display=swap" rel="stylesheet" />
   <title>Fashion ERP</title>
 </head>
 <body>

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,6 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import { ThemeProvider } from './theme';
 
 const root = ReactDOM.createRoot(document.getElementById('root')!);
-root.render(<React.StrictMode><App /></React.StrictMode>);
+root.render(
+  <React.StrictMode>
+    <ThemeProvider>
+      <App />
+    </ThemeProvider>
+  </React.StrictMode>
+);

--- a/frontend/src/theme/index.ts
+++ b/frontend/src/theme/index.ts
@@ -1,0 +1,28 @@
+/**
+ * Paleta corporativa con contraste mínimo 4.5:1 (WCAG AA)
+ */
+import { PropsWithChildren, ReactNode } from 'react';
+import { createTheme, ThemeProvider as MuiThemeProvider } from '@mui/material/styles';
+
+const theme = createTheme({
+  palette: {
+    mode: 'light',
+    primary: { main: '#c1121f', contrastText: '#fdf0d5' },
+    secondary: { main: '#669bbc', contrastText: '#003049' },
+    error: { main: '#780000', contrastText: '#fdf0d5' },
+    info: { main: '#003049', contrastText: '#fdf0d5' },
+    background: {
+      default: '#fdf0d5',
+      paper: '#fdf0d5',
+    },
+  },
+  typography: {
+    fontFamily: `'Google Sans', sans-serif`,
+  },
+});
+
+export function ThemeProvider({ children }: PropsWithChildren<ReactNode>) {
+  return <MuiThemeProvider theme={theme}>{children}</MuiThemeProvider>;
+}
+
+export default theme;


### PR DESCRIPTION
## Summary
- add global MUI ThemeProvider with corporate colors and Google Sans
- import theme in entrypoint and load Google Sans font
- document palette and WCAG contrast guideline

## Testing
- `pnpm lint` *(fails: ESLint couldn't find a configuration file)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6845f5315fd0832ba9229aa7fee90992