### PR TITLE
Fix PNPM detection in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,9 @@ jobs:
           node-version: 20
           cache: 'pnpm'
 
-      - name: Enable pnpm
-        run: |
-          corepack enable
-          corepack prepare pnpm@9.15.4 --activate
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 9.15.4
 
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Summary
- fix failing GitHub Actions build by installing PNPM via `pnpm/action-setup`

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm -r --if-present lint`
- `pnpm -r --if-present test`
- `pytest -q`
- `pnpm build-storybook`


------
https://chatgpt.com/codex/tasks/task_e_6846d26466d0832bb4a0d465f14ba97c