### PR TITLE
Initialize modular FastAPI backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,6 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+# Python
+__pycache__/
+.venv/

--- a/backend/app/api/router.py
+++ b/backend/app/api/router.py
@@ -1,0 +1,8 @@
+from fastapi import APIRouter
+
+router = APIRouter()
+
+
+@router.get("/health", tags=["system"])
+async def health() -> dict[str, str]:
+    return {"status": "ok"}

--- a/backend/app/core/__init__.py
+++ b/backend/app/core/__init__.py
@@ -1,0 +1,4 @@
+from .logging import configure_logging
+from .settings import settings
+
+__all__ = ["settings", "configure_logging"]

--- a/backend/app/core/logging.py
+++ b/backend/app/core/logging.py
@@ -1,0 +1,7 @@
+from loguru import logger
+
+
+def configure_logging(level: str) -> None:
+    """Configure global logging."""
+    logger.remove()
+    logger.add(lambda msg: print(msg, end=""), level=level)

--- a/backend/app/core/settings.py
+++ b/backend/app/core/settings.py
@@ -1,0 +1,14 @@
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Application settings loaded from environment."""
+
+    model_config = SettingsConfigDict(env_file=".env")
+
+    app_name: str = "Fashion ERP API"
+    log_level: str = "INFO"
+    allowed_origins: list[str] = ["http://localhost:3000"]
+
+
+settings = Settings()  # type: ignore[misc]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,8 +1,23 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 
-app = FastAPI(title="Fashion ERP API")
+from .api.router import router
+from .core import configure_logging, settings
 
 
-@app.get("/health")
-def health() -> dict[str, str]:
-    return {"status": "ok"}
+def create_app() -> FastAPI:
+    configure_logging(settings.log_level)
+
+    app = FastAPI(title=settings.app_name)
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=settings.allowed_origins,
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+    app.include_router(router)
+    return app
+
+
+app = create_app()

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,0 +1,10 @@
+from app.main import app
+from fastapi.testclient import TestClient
+
+client = TestClient(app)
+
+
+def test_health() -> None:
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 fastapi==0.115.2
 uvicorn[standard]==0.23.2
 pydantic==2.7.1
+pydantic-settings==2.2.1
 python-multipart==0.0.9
 
 # --- persistence ---


### PR DESCRIPTION
## Summary
- set up modular FastAPI structure
- add core settings and logging helpers
- configure CORS and health router
- include basic health test
- ignore Python cache files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684709fb9008832bbfbeb545fc1da7e4