### PR TITLE
Define dependencias backend separadas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         run: pnpm -r --if-present lint
 
       - name: Backend dependencies
-        run: pip install -r requirements.txt
+        run: pip install -r requirements.txt -r requirements.dev.txt
 
       - name: Tests frontend
         run: pnpm -r --if-present test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ docs(agents): aclara flujo de revisión para IA Codex
 * Seguridad: OAuth2 + JWT; hash de pass = `bcrypt`.
 * CORS activado para `http://localhost:3000` y dominios configurados.
 * Observabilidad OTel: cada request genera trace-id propagado a front.
+* Dependencias separadas: `requirements.txt` (runtime) y `requirements.dev.txt` (lint, tests, mypy).
 
 ### 5. Infra & Dev Ops
 * Docker: un proceso por contenedor; `docker-compose -f docker-compose.dev.yml up`.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ pnpm run dev       # http://localhost:3000
 # Back-end
 cd ../backend
 python -m venv .venv && source .venv/bin/activate
-pip install -r requirements.txt
+pip install -r requirements.txt -r requirements.dev.txt
 uvicorn app.main:app --reload  # http://localhost:8000/docs
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,3 +3,4 @@
 Este directorio contiene la documentación general del proyecto. Consulta `agents.md` para las guías de colaboración.
 
 - [Estrategia de enrutamiento y estado](routing-estado.md)
+- [Dependencias backend](backend-dependencies.md)

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -33,6 +33,7 @@ docs(agents): aclara flujo de revisión para IA Codex
 * Seguridad: OAuth2 + JWT; hash de pass = `bcrypt`.
 * CORS activado para `http://localhost:3000` y dominios configurados.
 * Observabilidad OTel: cada request genera trace-id propagado a front.
+* Dependencias separadas: `requirements.txt` (runtime) y `requirements.dev.txt` (lint, tests, mypy).
 
 ### 5. Infra & Dev Ops
 * Docker: un proceso por contenedor; `docker-compose -f docker-compose.dev.yml up`.

--- a/docs/backend-dependencies.md
+++ b/docs/backend-dependencies.md
@@ -1,0 +1,22 @@
+# Dependencias del Backend
+
+Las librerías de Python se agrupan en dos archivos para simplificar la gestión de entornos.
+
+- `requirements.txt`: **dependencias de runtime** necesarias para ejecutar la API en producción.
+- `requirements.dev.txt`: herramientas de **desarrollo** (lint, type checking, pruebas).
+
+Para instalar todo en un entorno local se combinan ambos archivos:
+
+```bash
+pip install -r requirements.txt -r requirements.dev.txt
+```
+
+## Actualización sin romper imágenes Docker
+
+1. Actualiza y fija versiones en ambos archivos.
+2. Construye nuevamente la imagen del backend para que Docker cachee las capas de `pip install`:
+   ```bash
+   docker compose build backend
+   ```
+3. Ejecuta los tests (`pytest`) antes de publicar la nueva imagen.
+4. Si la imagen ya está publicada, incrementa la etiqueta de versión para evitar conflictos de cache en los entornos desplegados.

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,0 +1,13 @@
+# --- lint ---
+ruff==0.11.13
+black==25.1.0
+isort==6.0.1
+
+# --- type checking ---
+mypy==1.16.0
+
+# --- testing ---
+pytest==8.2.0
+pytest-asyncio==0.23.6
+httpx==0.27.0
+coverage==7.5.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,17 +21,13 @@ python-dotenv==1.0.1
 celery==5.3.6
 redis==5.0.4
 
+
 # --- observabilidad ---
 opentelemetry-api==1.25.0
 opentelemetry-sdk==1.25.0
 opentelemetry-exporter-otlp==1.25.0
 loguru==0.7.2
 
-# --- testing ---
-pytest==8.2.0
-pytest-asyncio==0.23.6
-httpx==0.27.0
-coverage==7.5.3
 
 # --- misc ---
 orjson==3.10.4            # super-fast JSON


### PR DESCRIPTION
## Summary
- separar dependencias de runtime y desarrollo
- documentar instalación y actualización de dependencias backend
- actualizar CI para usar ambos requirements
- reflejar en AGENTS la nueva norma

## Testing
- `ruff check backend`
- `isort backend`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68470c1877d0832b8ed4f8a866f520b5