### PR TITLE
Add health smoke test

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ uvicorn app.main:app --reload  # http://localhost:8000/docs
 | `pytest -q`                                       | Ejecuta tests backend                     |
 | `docker-compose -f docker-compose.dev.yml up`     | Entorno completo (db, redis, front, back) |
 
+## Ejecutar pruebas
+
+```bash
+cd backend
+pytest -q
+```
+
+
 ## Estrategia Docker
 - Multi-stage build para imágenes pequeñas.
 - Separación: frontend, backend, db, redis, storybook.

--- a/backend/tests/test_smoke.py
+++ b/backend/tests/test_smoke.py
@@ -1,0 +1,9 @@
+from app.main import app
+from fastapi.testclient import TestClient
+
+client = TestClient(app)
+
+
+def test_health_status_code() -> None:
+    response = client.get("/health")
+    assert response.status_code == 200


### PR DESCRIPTION
## Summary
- add first smoke test to check `/health` endpoint
- document how to run the tests in README

## Testing
- `pip install -r requirements.txt -r requirements.dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68471986ab40832bb926393a4a40ad92