### PR TITLE
Configure Python formatting and type checks

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-cd frontend && npx lint-staged
+cd frontend && npx lint-staged && cd ..
+pre-commit run --files $(git diff --cached --name-only)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 25.1.0
+    hooks:
+      - id: black
+        args: ["--config", "pyproject.toml"]
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.0.292
+    hooks:
+      - id: ruff
+        args: ["--config", "pyproject.toml", "--fix"]
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.16.0
+    hooks:
+      - id: mypy
+        args: ["--config-file", "pyproject.toml"]

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,1 @@
+"App package"

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,5 +1,6 @@
-from app.main import app
 from fastapi.testclient import TestClient
+
+from app.main import app
 
 client = TestClient(app)
 

--- a/backend/tests/test_smoke.py
+++ b/backend/tests/test_smoke.py
@@ -1,5 +1,6 @@
-from app.main import app
 from fastapi.testclient import TestClient
+
+from app.main import app
 
 client = TestClient(app)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,26 @@
+[tool.black]
+line-length = 88
+target-version = ['py312']
+include = '\.pyi?$'
+
+[tool.isort]
+profile = "black"
+line_length = 88
+known_first_party = ["app"]
+
+[tool.ruff]
+line-length = 88
+target-version = "py312"
+select = ["E", "F", "I"]
+fix = true
+src = ["backend/app", "backend/tests"]
+
+[tool.ruff.isort]
+known-first-party = ["app"]
+
+[tool.mypy]
+python_version = "3.12"
+ignore_missing_imports = true
+disallow_untyped_defs = true
+check_untyped_defs = true
+

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -2,6 +2,7 @@
 ruff==0.11.13
 black==25.1.0
 isort==6.0.1
+pre-commit==3.7.0
 
 # --- type checking ---
 mypy==1.16.0


### PR DESCRIPTION
## Summary
- configure Black, Ruff, isort and mypy via `pyproject.toml`
- add pre-commit configuration to run formatters and type checker
- run pre-commit from Husky hook
- include pre-commit in dev requirements
- mark backend `app` as a Python package

## Testing
- `pre-commit run --files $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6847372cfc74832b8c3b1eb41b719d20