### PR TITLE
feat(core): structured logging and middleware

### DIFF
--- a/backend/app/core/logging.py
+++ b/backend/app/core/logging.py
@@ -1,7 +1,29 @@
+"""Logging helpers."""
+
+from __future__ import annotations
+
+import sys
+
 from loguru import logger
 
 
-def configure_logging(level: str) -> None:
-    """Configure global logging."""
+def configure_logging(level: str, json_logs: bool) -> None:
+    """Configure global structured logging.
+
+    Parameters
+    ----------
+    level:
+        Desired log level (e.g. ``"INFO"``).
+    json_logs:
+        When ``True`` logs are serialized as JSON.
+    """
+
     logger.remove()
-    logger.add(lambda msg: print(msg, end=""), level=level)
+    logger.add(
+        sys.stdout,
+        level=level,
+        serialize=json_logs,
+        enqueue=True,
+        backtrace=True,
+        diagnose=False,
+    )

--- a/backend/app/core/middleware.py
+++ b/backend/app/core/middleware.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import time
+from typing import Callable
+
+from loguru import logger
+from opentelemetry import trace
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+
+class ObservabilityMiddleware(BaseHTTPMiddleware):
+    """Capture response times and trace identifiers."""
+
+    async def dispatch(
+        self, request: Request, call_next: Callable[[Request], Response]
+    ) -> Response:
+        tracer = trace.get_tracer("app.middleware")
+        with tracer.start_as_current_span(f"{request.method} {request.url.path}"):
+            start = time.perf_counter()
+            response = await call_next(request)
+            duration_ms = (time.perf_counter() - start) * 1000
+            span = trace.get_current_span()
+            trace_id = f"{span.get_span_context().trace_id:032x}"
+            logger.bind(
+                path=request.url.path,
+                method=request.method,
+                status_code=response.status_code,
+                duration_ms=round(duration_ms, 2),
+                trace_id=trace_id,
+            ).info("request_completed")
+            response.headers["X-Response-Time"] = f"{duration_ms:.2f}ms"
+            response.headers["X-Trace-Id"] = trace_id
+            return response

--- a/backend/app/core/settings.py
+++ b/backend/app/core/settings.py
@@ -8,6 +8,7 @@ class Settings(BaseSettings):
 
     app_name: str = "Fashion ERP API"
     log_level: str = "INFO"
+    log_json: bool = False
     allowed_origins: list[str] = ["http://localhost:3000"]
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,12 +3,14 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from .api.router import router
 from .core import configure_logging, settings
+from .core.middleware import ObservabilityMiddleware
 
 
 def create_app() -> FastAPI:
-    configure_logging(settings.log_level)
+    configure_logging(settings.log_level, settings.log_json)
 
     app = FastAPI(title=settings.app_name)
+    app.add_middleware(ObservabilityMiddleware)
     app.add_middleware(
         CORSMiddleware,
         allow_origins=settings.allowed_origins,


### PR DESCRIPTION
## Summary
- implement structured Loguru setup with optional JSON
- add ObservabilityMiddleware for response times and trace info
- expose logging options via settings and wire into `create_app`

## Testing
- `pre-commit run --files backend/app/core/logging.py backend/app/core/settings.py backend/app/core/middleware.py backend/app/main.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6847416c2c80832bb7bcb350001d5058