### PR TITLE
docs(api): establece contrato versionado

### DIFF
--- a/backend/app/api/router.py
+++ b/backend/app/api/router.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-router = APIRouter()
+router = APIRouter(prefix="/api/v1")
 
 
 @router.get("/health", tags=["system"])

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -6,6 +6,6 @@ client = TestClient(app)
 
 
 def test_health() -> None:
-    response = client.get("/health")
+    response = client.get("/api/v1/health")
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}

--- a/backend/tests/test_smoke.py
+++ b/backend/tests/test_smoke.py
@@ -6,5 +6,5 @@ client = TestClient(app)
 
 
 def test_health_status_code() -> None:
-    response = client.get("/health")
+    response = client.get("/api/v1/health")
     assert response.status_code == 200

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,3 +4,4 @@ Este directorio contiene la documentación general del proyecto. Consulta `agent
 
 - [Estrategia de enrutamiento y estado](routing-estado.md)
 - [Dependencias backend](backend-dependencies.md)
+- [Versionado de API](api-versioning.md)

--- a/docs/api-versioning.md
+++ b/docs/api-versioning.md
@@ -1,0 +1,30 @@
+# Contrato de Versionado de la API
+
+Todas las rutas públicas expuestas por FastAPI se agrupan bajo el prefijo `/api/v1`. Esta convención se aplica tanto para dominios internos como para integraciones de terceros.
+
+## Nomenclatura
+
+- `v{n}` indica la versión **mayor**. Ejemplo: `v1`, `v2`, `v3`.
+- Cambios menores o de seguridad no alteran el prefijo; se documentan en las notas de versión.
+- Las nuevas versiones conviven con las anteriores para evitar rupturas inmediatas.
+
+## Ciclo de deprecación
+
+1. Cuando un endpoint vaya a retirarse se marcará con `deprecated: true` en el esquema OpenAPI y se enviará el encabezado `Deprecation: true`.
+2. Cada versión mayor tendrá soporte durante al menos una release menor tras publicarse la siguiente.
+3. La fecha de retiro definitivo se comunicará en los canales de release y en este documento.
+
+## Ejemplo de rutas
+
+```text
+GET /api/v1/ventas/pedidos
+GET /api/v2/ventas/pedidos
+```
+
+Al crear una nueva versión se definirá un nuevo router en FastAPI:
+
+```python
+router_v2 = APIRouter(prefix="/api/v2")
+```
+
+Esto garantiza que el front-end y clientes externos puedan migrar de forma gradual.


### PR DESCRIPTION
## Summary
- document API versioning strategy
- expose `/api/v1` prefix in FastAPI router
- update tests with new path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68476f1fa6cc832b82b59c94080164d7