### PR TITLE
Enable CORS via ALLOWED_ORIGINS env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,4 @@ FRONTEND_PORT=3000
 BACKEND_PORT=8000
 DATABASE_URL=postgresql+asyncpg://erp:erp@db:5432/erp
 REDIS_URL=redis://redis:6379/0
+ALLOWED_ORIGINS=http://localhost:3000

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ docs(agents): aclara flujo de revisión para IA Codex
 * **Pydantic v2** para validación; usa `field_validators` cuando aplique.
 * DB **PostgreSQL** → SQLAlchemy 2 (async); migraciones = Alembic.
 * Seguridad: OAuth2 + JWT; hash de pass = `bcrypt`.
-* CORS activado para `http://localhost:3000` y dominios configurados.
+* CORS activado solo para orígenes listados en `.env` (`ALLOWED_ORIGINS`).
 * Observabilidad OTel: cada request genera trace-id propagado a front.
 * Dependencias separadas: `requirements.txt` (runtime) y `requirements.dev.txt` (lint, tests, mypy).
 

--- a/backend/app/core/settings.py
+++ b/backend/app/core/settings.py
@@ -1,3 +1,4 @@
+from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -9,7 +10,14 @@ class Settings(BaseSettings):
     app_name: str = "Fashion ERP API"
     log_level: str = "INFO"
     log_json: bool = False
-    allowed_origins: list[str] = ["http://localhost:3000"]
+    allowed_origins: list[str] = Field(default_factory=list)
+
+    @field_validator("allowed_origins", mode="before")
+    @classmethod
+    def split_origins(cls, v: str | list[str]) -> list[str]:
+        if isinstance(v, str):
+            return [origin.strip() for origin in v.split(",") if origin.strip()]
+        return v
 
 
 settings = Settings()  # type: ignore[misc]

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -31,7 +31,7 @@ docs(agents): aclara flujo de revisión para IA Codex
 * **Pydantic v2** para validación; usa `field_validators` cuando aplique.
 * DB **PostgreSQL** → SQLAlchemy 2 (async); migraciones = Alembic.
 * Seguridad: OAuth2 + JWT; hash de pass = `bcrypt`.
-* CORS activado para `http://localhost:3000` y dominios configurados.
+* CORS activado solo para orígenes listados en `.env` (`ALLOWED_ORIGINS`).
 * Observabilidad OTel: cada request genera trace-id propagado a front.
 * Dependencias separadas: `requirements.txt` (runtime) y `requirements.dev.txt` (lint, tests, mypy).
 


### PR DESCRIPTION
## Summary
- read `ALLOWED_ORIGINS` from environment and parse list
- document new variable in `AGENTS.md` and `docs/agents.md`
- add example `ALLOWED_ORIGINS` to `.env.example`

## Testing
- `pre-commit run --files backend/app/core/settings.py .env.example AGENTS.md docs/agents.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684770ef4754832b88a4e546acd4f182