### PR TITLE
Frontend Docker multi-stage

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+.dockerignore
+Dockerfile
+Dockerfile.dev
+*.log
+src/**/*.test.*
+.storybook

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,6 +1,12 @@
-FROM node:20-alpine
+FROM node:20-alpine AS builder
 WORKDIR /app
 COPY package.json pnpm-lock.yaml ./
 RUN npm install -g pnpm && pnpm install --frozen-lockfile
 COPY . .
-CMD ["pnpm","run","dev"]
+RUN pnpm run build
+
+FROM nginx:1.27-alpine AS production
+COPY --from=builder /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80
+CMD ["nginx","-g","daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,10 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
## Summary
- use multi-stage build in `frontend/Dockerfile`
- add nginx config for SPA routing
- ignore node_modules in Docker context

## Testing
- `pytest -q`
- `pnpm --filter ./frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68477281d15c832b86ef403abf850f62