### PR TITLE
Add development Docker Compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ uvicorn app.main:app --reload  # http://localhost:8000/docs
 | `pnpm run build`                                   | Compila la SPA en `dist/`                 |
 | `pnpm run storybook`                               | Doc y sandbox de componentes (:6006)      |
 | `pytest -q`                                       | Ejecuta tests backend                     |
-| `docker-compose -f docker-compose.dev.yml up`     | Entorno completo (db, redis, front, back) |
+| `docker-compose -f docker-compose.dev.yml up`     | Entorno completo (db, front, back) |
 
 ## Ejecutar pruebas
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,40 @@
+version: '3.9'
+
+services:
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: erp
+      POSTGRES_PASSWORD: erp
+      POSTGRES_DB: erp
+    ports:
+      - "5432:5432"
+    volumes:
+      - db-data:/var/lib/postgresql/data
+
+  backend:
+    build: ./backend
+    environment:
+      DATABASE_URL: postgresql+asyncpg://erp:erp@db:5432/erp
+    volumes:
+      - ./backend:/app
+    ports:
+      - "8000:8000"
+    command: uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
+    depends_on:
+      - db
+
+  frontend:
+    build: ./frontend
+    environment:
+      VITE_API_URL: http://localhost:8000/api/v1
+    volumes:
+      - ./frontend:/app
+    ports:
+      - "3000:3000"
+    command: pnpm run dev
+    depends_on:
+      - backend
+
+volumes:
+  db-data:


### PR DESCRIPTION
## Summary
- add `docker-compose.dev.yml` for local orchestration
- clarify which services start via compose in README

## Testing
- `ruff check .`
- `black --check .`
- `isort --check .`
- `pnpm lint`
- `pnpm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68477a96f240832b88d361c23cdcef74