### PR TITLE
Update .env template and usage docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,16 @@
-# Sample environment variables
-FRONTEND_PORT=3000
+# One ERP environment template
+
+# ---- API ----
 BACKEND_PORT=8000
+VITE_API_URL=http://localhost:8000/api/v1
+ALLOWED_ORIGINS=http://localhost:3000
+
+# ---- Database ----
+POSTGRES_USER=erp
+POSTGRES_PASSWORD=erp
+POSTGRES_DB=erp
 DATABASE_URL=postgresql+asyncpg://erp:erp@db:5432/erp
 REDIS_URL=redis://redis:6379/0
-ALLOWED_ORIGINS=http://localhost:3000
+
+# ---- Keys ----
+JWT_SECRET_KEY=change-me

--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@
 4. [Instalación rápida](#instalación-rápida)
 5. [Scripts pnpm / CLI](#scripts-pnpm--cli)
 6. [Estrategia Docker](#estrategia-docker)
-7. [Entornos](#entornos)
-8. [Contribuir](#contribuir)
-9. [Licencia](#licencia)
+7. [Variables de entorno](#variables-de-entorno)
+8. [Entornos](#entornos)
+9. [Contribuir](#contribuir)
+10. [Licencia](#licencia)
 
 ---
 
@@ -88,6 +89,15 @@ pytest -q
 - Separación: frontend, backend, db, redis, storybook.
 - Volúmenes montados solo en dev para hot-reload.
 - Variables de entorno declaradas en `.env` (no commit real keys).
+
+## Variables de entorno
+1. Copia `\.env.example` a `\.env` en la raíz del proyecto.
+2. Ajusta los valores de API, base de datos y claves según tu entorno.
+
+```bash
+cp .env.example .env
+# luego edita .env
+```
 
 ## Entornos
 


### PR DESCRIPTION
## Summary
- expand `.env.example` with API, database and key variables
- explain how to create a local `.env` in the README

## Testing
- `pre-commit run --files README.md .env.example`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68477ddcb7e4832bba613a5c90cc4175