### PR TITLE
Configure dependabot and publish security docs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@ docs(agents): aclara flujo de revisión para IA Codex
 * Secrets via GitHub Secrets (nunca en el repo).
 * RPO ≤ 15 min, RTO ≤ 30 min (ver runbooks en `/docs/dr`).
 * Gestor Node = PNPM; habilita `corepack` para versiones homogéneas.
+* Dependabot alerts activos para actualizar dependencias de Node y Python.
 
 ### 6. Estilo de código
 * **Python**: `ruff` + `black --line-length 88` + `isort`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,14 @@
+# Política de Seguridad
+
+Este proyecto sigue un modelo de **divulgación responsable**.
+
+## Reportar vulnerabilidades
+1. Crea un correo a `security@one-erp.com` con los detalles y pasos para reproducir.
+2. No abras un issue público hasta recibir confirmación del equipo.
+3. Te responderemos en un plazo de 72 horas con los siguientes pasos.
+
+## Límites
+- No realices pruebas que afecten a datos de terceros.
+- Evita la divulgación prematura de exploits.
+
+Agradecemos tu colaboración para mantener seguro el ecosistema.

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,3 +5,4 @@ Este directorio contiene la documentación general del proyecto. Consulta `agent
 - [Estrategia de enrutamiento y estado](routing-estado.md)
 - [Dependencias backend](backend-dependencies.md)
 - [Versionado de API](api-versioning.md)
+- [Flujo de seguridad](security-flow.md)

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -41,6 +41,7 @@ docs(agents): aclara flujo de revisión para IA Codex
 * Secrets via GitHub Secrets (nunca en el repo).
 * RPO ≤ 15 min, RTO ≤ 30 min (ver runbooks en `/docs/dr`).
 * Gestor Node = PNPM; habilita `corepack` para versiones homogéneas.
+* Dependabot alerts activos para actualizar dependencias de Node y Python.
 
 ### 6. Estilo de código
 * **Python**: `ruff` + `black --line-length 88` + `isort`.

--- a/docs/security-flow.md
+++ b/docs/security-flow.md
@@ -1,0 +1,19 @@
+# Flujo de Seguridad Básica
+
+Este documento resume las tareas mínimas para mantener seguro el proyecto.
+
+## 1. Monitoreo continuo
+- **Dependabot** está habilitado para Python y Node.
+- Cada alerta genera un PR automático que debe revisarse en 24 horas.
+
+## 2. Gestión de credenciales
+- Las claves se almacenan en **GitHub Secrets** y nunca se versionan.
+- Revisa periódicamente los permisos de los colaboradores.
+
+## 3. Respuesta ante vulnerabilidades
+- Sigue la guía de `SECURITY.md` para reportar problemas.
+- Usa `pytest` y `pnpm test` para validar los parches antes de desplegar.
+
+## 4. Auditoría
+- Ejecuta `ruff` y `eslint` como parte de la CI.
+- Los resultados se almacenan en el historial de GitHub Actions.


### PR DESCRIPTION
## Summary
- enable automated dependency monitoring with Dependabot
- document new security flow and disclosure policy
- reference security docs in the developer guide

## Testing
- `pre-commit run --files AGENTS.md docs/agents.md docs/README.md docs/security-flow.md .github/dependabot.yml SECURITY.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68478fc4f508832b97a4b81f5ee9d713