### PR TITLE
Fix wrong backend URL in docker-compose.dev

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -27,7 +27,7 @@ services:
   frontend:
     build: ./frontend
     environment:
-      VITE_API_URL: http://localhost:8000/api/v1
+      VITE_API_URL: http://backend:8000/api/v1
     volumes:
       - ./frontend:/app
     ports:


### PR DESCRIPTION
## Summary
- fix frontend service API URL in docker-compose.dev.yml

## Testing
- `ruff check .`
- `black --check --line-length 88 .`
- `isort --check .`
- `pytest -q`
- `pnpm lint`
- `pnpm test -- --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_6847953e9994832bb713e8f21b75b37b