### PR TITLE
feat(ui): agrega PrimaryButton

### DIFF
--- a/frontend/src/components/atoms/PrimaryButton.stories.tsx
+++ b/frontend/src/components/atoms/PrimaryButton.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import SaveIcon from '@mui/icons-material/Save';
+import { PrimaryButton } from './PrimaryButton';
+
+const meta: Meta<typeof PrimaryButton> = {
+  title: 'Atoms/PrimaryButton',
+  component: PrimaryButton,
+  args: {
+    children: 'Save',
+  },
+  argTypes: {
+    onClick: { action: 'clicked' },
+    startIcon: { control: false },
+    endIcon: { control: false },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof PrimaryButton>;
+
+export const Default: Story = {};
+
+export const Disabled: Story = {
+  args: { disabled: true, children: "Can't click" },
+};
+
+export const WithIcon: Story = {
+  args: { startIcon: <SaveIcon /> },
+};
+
+export const Loading: Story = {
+  args: { loading: true },
+};

--- a/frontend/src/components/atoms/PrimaryButton.test.tsx
+++ b/frontend/src/components/atoms/PrimaryButton.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { PrimaryButton } from './PrimaryButton';
+import { ThemeProvider } from '../../theme';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('PrimaryButton', () => {
+  it('calls onClick when enabled', async () => {
+    const user = userEvent.setup();
+    const handleClick = jest.fn();
+    renderWithTheme(<PrimaryButton onClick={handleClick}>Save</PrimaryButton>);
+    await user.click(screen.getByRole('button', { name: /save/i }));
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onClick when disabled', async () => {
+    const handleClick = jest.fn();
+    renderWithTheme(
+      <PrimaryButton onClick={handleClick} disabled>
+        Disabled
+      </PrimaryButton>,
+    );
+    const btn = screen.getByRole('button', { name: /disabled/i });
+    btn.click();
+    expect(handleClick).not.toHaveBeenCalled();
+  });
+
+  it('shows loading spinner and prevents click when loading', async () => {
+    const handleClick = jest.fn();
+    renderWithTheme(
+      <PrimaryButton onClick={handleClick} loading>
+        Loading
+      </PrimaryButton>,
+    );
+    const btn = screen.getByRole('button');
+    expect(btn).toBeDisabled();
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    btn.click();
+    expect(handleClick).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/atoms/PrimaryButton.tsx
+++ b/frontend/src/components/atoms/PrimaryButton.tsx
@@ -1,0 +1,36 @@
+import { CircularProgress } from '@mui/material';
+import { PropsWithChildren } from 'react';
+import Button, { ButtonProps } from './Button';
+
+export interface PrimaryButtonProps extends ButtonProps {
+  loading?: boolean;
+}
+
+/**
+ * Botón primario que muestra la acción principal de cada vista.
+ */
+export function PrimaryButton({
+  children,
+  onClick,
+  disabled = false,
+  startIcon,
+  endIcon,
+  loading = false,
+  ...props
+}: PropsWithChildren<PrimaryButtonProps>) {
+  return (
+    <Button
+      variant="contained"
+      color="primary"
+      startIcon={startIcon}
+      endIcon={endIcon}
+      disabled={disabled || loading}
+      onClick={onClick}
+      {...props}
+    >
+      {loading ? <CircularProgress size={20} color="inherit" /> : children}
+    </Button>
+  );
+}
+
+export default PrimaryButton;


### PR DESCRIPTION
## Summary
- add PrimaryButton atom based on MUI Button
- add tests for disabled and loading states
- document PrimaryButton in Storybook

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847afbc7c5c832b91dedddf7826bc46