### PR TITLE
Add SecondaryButton atom

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,6 @@
+export default {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['@testing-library/jest-dom/extend-expect'],
+  moduleDirectories: ['node_modules', 'src'],
+};

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-react": "^7.34.1",
     "jest": "^29.7.0",
+    "ts-jest": "^29.3.4",
     "prettier": "^3.2.5",
     "storybook": "^8.5.0",
     "typescript": "^5.5.2",

--- a/src/components/atoms/SecondaryButton.stories.mdx
+++ b/src/components/atoms/SecondaryButton.stories.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import { SecondaryButton } from './SecondaryButton';
+import * as Stories from './SecondaryButton.stories';
+
+<Meta of={Stories} />
+
+# SecondaryButton
+
+Use the SecondaryButton for secondary actions. It wraps MUI `Button` with the `outlined` variant and `secondary` color.
+
+<Story id="atoms-secondarybutton--default" />
+
+<ArgsTable of={SecondaryButton} story="Default" />

--- a/src/components/atoms/SecondaryButton.stories.tsx
+++ b/src/components/atoms/SecondaryButton.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { SecondaryButton } from './SecondaryButton';
+import SaveIcon from '@mui/icons-material/Save';
+import DeleteIcon from '@mui/icons-material/Delete';
+
+const meta: Meta<typeof SecondaryButton> = {
+  title: 'Atoms/SecondaryButton',
+  component: SecondaryButton,
+  args: {
+    children: 'Secondary action',
+    disabled: false,
+  },
+  argTypes: {
+    children: { control: 'text' },
+    disabled: { control: 'boolean' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof SecondaryButton>;
+
+export const Default: Story = {};
+
+export const Disabled: Story = {
+  args: { disabled: true },
+};
+
+export const WithIcons: Story = {
+  args: {
+    startIcon: <SaveIcon />,
+    endIcon: <DeleteIcon />,
+  },
+};

--- a/src/components/atoms/SecondaryButton.test.tsx
+++ b/src/components/atoms/SecondaryButton.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { SecondaryButton } from './SecondaryButton';
+
+test('renders the provided text', () => {
+  render(<SecondaryButton>Click me</SecondaryButton>);
+  expect(screen.getByRole('button', { name: /click me/i })).toBeInTheDocument();
+});
+
+test('disabled button does not trigger onClick', async () => {
+  const user = userEvent.setup();
+  const handleClick = jest.fn();
+  render(
+    <SecondaryButton disabled onClick={handleClick}>
+      Do action
+    </SecondaryButton>
+  );
+  const button = screen.getByRole('button', { name: /do action/i });
+  expect(button).toBeDisabled();
+  await user.click(button);
+  expect(handleClick).not.toHaveBeenCalled();
+});

--- a/src/components/atoms/SecondaryButton.tsx
+++ b/src/components/atoms/SecondaryButton.tsx
@@ -1,0 +1,34 @@
+import Button, { type ButtonProps } from '@mui/material/Button';
+import { type ReactNode } from 'react';
+
+export interface SecondaryButtonProps
+  extends Omit<ButtonProps, 'variant' | 'color'> {
+  children: ReactNode;
+  onClick?: React.MouseEventHandler<HTMLButtonElement>;
+  disabled?: boolean;
+  startIcon?: React.ReactNode;
+  endIcon?: React.ReactNode;
+}
+
+export const SecondaryButton = ({
+  children,
+  onClick,
+  disabled = false,
+  startIcon,
+  endIcon,
+  ...props
+}: SecondaryButtonProps) => (
+  <Button
+    variant="outlined"
+    color="secondary"
+    onClick={onClick}
+    disabled={disabled}
+    startIcon={startIcon}
+    endIcon={endIcon}
+    {...props}
+  >
+    {children}
+  </Button>
+);
+
+export default SecondaryButton;

--- a/src/components/atoms/index.ts
+++ b/src/components/atoms/index.ts
@@ -1,0 +1,1 @@
+export { SecondaryButton } from './SecondaryButton';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,1 @@
+export * from './components/atoms';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "ESNext",
+    "jsx": "react-jsx",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add `SecondaryButton` component using MUI
- export atoms from root module
- document component with stories and MDX
- add unit tests
- add tsconfig and jest config to enable testing

## Testing
- `npm test` *(fails: jest not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684816795280832b8e972b7e11b17ba9