### PR TITLE
Add SecondaryButton atom

### DIFF
--- a/frontend/src/components/atoms/SecondaryButton.stories.mdx
+++ b/frontend/src/components/atoms/SecondaryButton.stories.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './SecondaryButton.stories';
+import { SecondaryButton } from './SecondaryButton';
+
+<Meta of={Stories} />
+
+# SecondaryButton
+
+Botón para acciones secundarias, utiliza la variante `outlined` y color `secondary` de MUI.
+
+<Story id="atoms-secondarybutton--default" />
+
+<ArgsTable of={SecondaryButton} story="Default" />

--- a/frontend/src/components/atoms/SecondaryButton.stories.tsx
+++ b/frontend/src/components/atoms/SecondaryButton.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import SaveIcon from '@mui/icons-material/Save';
+import DeleteIcon from '@mui/icons-material/Delete';
+import { SecondaryButton } from './SecondaryButton';
+
+const meta: Meta<typeof SecondaryButton> = {
+  title: 'Atoms/SecondaryButton',
+  component: SecondaryButton,
+  args: {
+    children: 'Secondary action',
+  },
+  argTypes: {
+    onClick: { action: 'clicked' },
+    startIcon: { control: false },
+    endIcon: { control: false },
+    children: { control: 'text' },
+    disabled: { control: 'boolean' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof SecondaryButton>;
+
+export const Default: Story = {};
+
+export const Disabled: Story = {
+  args: { disabled: true, children: "Can't click" },
+};
+
+export const WithIcons: Story = {
+  args: {
+    startIcon: <SaveIcon />,
+    endIcon: <DeleteIcon />,
+  },
+};

--- a/frontend/src/components/atoms/SecondaryButton.test.tsx
+++ b/frontend/src/components/atoms/SecondaryButton.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react';
+import { SecondaryButton } from './SecondaryButton';
+import { ThemeProvider } from '../../theme';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('SecondaryButton', () => {
+  it('renders the provided text', () => {
+    renderWithTheme(<SecondaryButton>Cancel</SecondaryButton>);
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
+  });
+
+  it('does not call onClick when disabled', () => {
+    const handleClick = jest.fn();
+    renderWithTheme(
+      <SecondaryButton disabled onClick={handleClick}>
+        Disabled
+      </SecondaryButton>,
+    );
+    const btn = screen.getByRole('button', { name: /disabled/i });
+    expect(btn).toBeDisabled();
+    btn.click();
+    expect(handleClick).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/atoms/SecondaryButton.tsx
+++ b/frontend/src/components/atoms/SecondaryButton.tsx
@@ -1,0 +1,33 @@
+import { Button as MuiButton, ButtonProps as MuiButtonProps } from '@mui/material';
+import { PropsWithChildren } from 'react';
+
+export type SecondaryButtonProps = MuiButtonProps & PropsWithChildren;
+
+/**
+ * Botón secundario para acciones alternativas.
+ * Reutiliza `Button` de MUI con variante `outlined` y color `secondary`.
+ */
+export function SecondaryButton({
+  children,
+  onClick,
+  disabled = false,
+  startIcon,
+  endIcon,
+  ...props
+}: PropsWithChildren<SecondaryButtonProps>) {
+  return (
+    <MuiButton
+      variant="outlined"
+      color="secondary"
+      onClick={onClick}
+      disabled={disabled}
+      startIcon={startIcon}
+      endIcon={endIcon}
+      {...props}
+    >
+      {children}
+    </MuiButton>
+  );
+}
+
+export default SecondaryButton;

--- a/frontend/src/components/atoms/index.ts
+++ b/frontend/src/components/atoms/index.ts
@@ -1,0 +1,3 @@
+export { Button } from './Button';
+export { PrimaryButton } from './PrimaryButton';
+export { SecondaryButton } from './SecondaryButton';

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -1,0 +1,1 @@
+export * from './components/atoms';


### PR DESCRIPTION
## Summary
- add SecondaryButton with MUI `outlined`/`secondary`
- document in Storybook with MDX
- add unit tests for SecondaryButton
- export from atoms index and project entry

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68481d8a2bac832bb97c3b5fd31908e5