### PR TITLE
Add TertiaryButton atom

### DIFF
--- a/frontend/src/components/atoms/TertiaryButton.docs.mdx
+++ b/frontend/src/components/atoms/TertiaryButton.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './TertiaryButton.stories';
+import { TertiaryButton } from './TertiaryButton';
+
+<Meta of={Stories} />
+
+# TertiaryButton
+
+Botón para acciones de bajo énfasis o enlaces estilo botón.
+
+<Story id="atoms-tertiarybutton--default" />
+
+<ArgsTable of={TertiaryButton} story="Default" />

--- a/frontend/src/components/atoms/TertiaryButton.stories.tsx
+++ b/frontend/src/components/atoms/TertiaryButton.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
+import { TertiaryButton } from './TertiaryButton';
+
+const meta: Meta<typeof TertiaryButton> = {
+  title: 'Atoms/TertiaryButton',
+  component: TertiaryButton,
+  args: {
+    children: 'Tertiary action',
+  },
+  argTypes: {
+    onClick: { action: 'clicked' },
+    startIcon: { control: false },
+    endIcon: { control: false },
+    children: { control: 'text' },
+    disabled: { control: 'boolean' },
+    href: { control: 'text' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof TertiaryButton>;
+
+export const Default: Story = {};
+
+export const Disabled: Story = {
+  args: { disabled: true, children: "Can't click" },
+};
+
+export const WithIcon: Story = {
+  args: { endIcon: <ArrowForwardIcon /> },
+};

--- a/frontend/src/components/atoms/TertiaryButton.test.tsx
+++ b/frontend/src/components/atoms/TertiaryButton.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TertiaryButton } from './TertiaryButton';
+import { ThemeProvider } from '../../theme';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('TertiaryButton', () => {
+  it('renders the provided text', () => {
+    renderWithTheme(<TertiaryButton>Cancelar</TertiaryButton>);
+    expect(screen.getByRole('button', { name: /cancelar/i })).toBeInTheDocument();
+  });
+
+  it('calls onClick when enabled', async () => {
+    const user = userEvent.setup();
+    const handleClick = jest.fn();
+    renderWithTheme(<TertiaryButton onClick={handleClick}>Aceptar</TertiaryButton>);
+    await user.click(screen.getByRole('button', { name: /aceptar/i }));
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onClick when disabled', () => {
+    const handleClick = jest.fn();
+    renderWithTheme(
+      <TertiaryButton disabled onClick={handleClick}>
+        Disabled
+      </TertiaryButton>,
+    );
+    const btn = screen.getByRole('button', { name: /disabled/i });
+    expect(btn).toBeDisabled();
+    btn.click();
+    expect(handleClick).not.toHaveBeenCalled();
+  });
+
+  it('renders as link when href is provided', () => {
+    renderWithTheme(<TertiaryButton href="https://example.com">Link</TertiaryButton>);
+    const link = screen.getByRole('link', { name: /link/i });
+    expect(link).toHaveAttribute('href', 'https://example.com');
+  });
+});

--- a/frontend/src/components/atoms/TertiaryButton.tsx
+++ b/frontend/src/components/atoms/TertiaryButton.tsx
@@ -1,0 +1,40 @@
+import { Button as MuiButton, ButtonProps as MuiButtonProps } from '@mui/material';
+import { PropsWithChildren } from 'react';
+
+export type TertiaryButtonProps = MuiButtonProps & PropsWithChildren;
+
+/**
+ * Botón terciario para acciones de bajo énfasis o enlaces estilo botón.
+ * Usa la variante `text` y color `primary`.
+ */
+export function TertiaryButton({
+  children,
+  onClick,
+  disabled = false,
+  startIcon,
+  endIcon,
+  ...props
+}: PropsWithChildren<TertiaryButtonProps>) {
+  return (
+    <MuiButton
+      variant="text"
+      color="primary"
+      onClick={onClick}
+      disabled={disabled}
+      startIcon={startIcon}
+      endIcon={endIcon}
+      sx={{
+        textTransform: 'none',
+        '&:hover': {
+          textDecoration: 'underline',
+          backgroundColor: 'transparent',
+        },
+      }}
+      {...props}
+    >
+      {children}
+    </MuiButton>
+  );
+}
+
+export default TertiaryButton;

--- a/frontend/src/components/atoms/index.ts
+++ b/frontend/src/components/atoms/index.ts
@@ -1,3 +1,4 @@
 export { Button } from './Button';
 export { PrimaryButton } from './PrimaryButton';
 export { SecondaryButton } from './SecondaryButton';
+export { TertiaryButton } from './TertiaryButton';


### PR DESCRIPTION
## Summary
- add a TertiaryButton atom built on MUI text variant
- document the component in Storybook
- export the button in the atom barrel file
- add basic unit tests

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68482766bf00832b95753da6b8fe8c9b