### PR TITLE
feat(atoms): add Link component

### DIFF
--- a/frontend/src/components/atoms/Link.docs.mdx
+++ b/frontend/src/components/atoms/Link.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './Link.stories';
+import { Link } from './Link';
+
+<Meta of={Stories} />
+
+# Link
+
+Elemento para navegación o acciones que llevan a otra vista.
+
+<Story id="atoms-link--default" />
+
+<ArgsTable of={Link} story="Default" />

--- a/frontend/src/components/atoms/Link.stories.tsx
+++ b/frontend/src/components/atoms/Link.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Link } from './Link';
+
+const meta: Meta<typeof Link> = {
+  title: 'Atoms/Link',
+  component: Link,
+  args: {
+    href: '#',
+    children: 'Visit section',
+  },
+  argTypes: {
+    onClick: { action: 'clicked' },
+    children: { control: 'text' },
+    href: { control: 'text' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Link>;
+
+export const Default: Story = {};
+
+export const CustomColor: Story = {
+  args: { color: 'secondary' },
+};

--- a/frontend/src/components/atoms/Link.test.tsx
+++ b/frontend/src/components/atoms/Link.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Link } from './Link';
+import { ThemeProvider } from '../../theme';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('Link', () => {
+  it('renders the text and href', () => {
+    renderWithTheme(<Link href="/home">Go home</Link>);
+    const link = screen.getByRole('link', { name: /go home/i });
+    expect(link).toHaveAttribute('href', '/home');
+  });
+
+  it('calls onClick handler when provided', async () => {
+    const user = userEvent.setup();
+    const handleClick = jest.fn();
+    renderWithTheme(
+      <Link href="#" onClick={handleClick}>
+        Click me
+      </Link>,
+    );
+    await user.click(screen.getByRole('link', { name: /click me/i }));
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/atoms/Link.tsx
+++ b/frontend/src/components/atoms/Link.tsx
@@ -1,0 +1,28 @@
+import MuiLink, { LinkProps as MuiLinkProps } from '@mui/material/Link';
+import { PropsWithChildren } from 'react';
+
+export type LinkProps = MuiLinkProps & PropsWithChildren;
+
+/**
+ * Enlace de navegación basado en MUI `Link`.
+ * Aplica color primario y solo subraya al pasar el cursor.
+ */
+export function Link({
+  children,
+  color = 'primary',
+  underline = 'hover',
+  ...props
+}: LinkProps) {
+  return (
+    <MuiLink
+      color={color}
+      underline={underline}
+      sx={{ '&:visited': { color: 'inherit' } }}
+      {...props}
+    >
+      {children}
+    </MuiLink>
+  );
+}
+
+export default Link;

--- a/frontend/src/components/atoms/index.ts
+++ b/frontend/src/components/atoms/index.ts
@@ -3,3 +3,4 @@ export { PrimaryButton } from './PrimaryButton';
 export { SecondaryButton } from './SecondaryButton';
 export { TertiaryButton } from './TertiaryButton';
 export { IconButton } from './IconButton';
+export { Link } from './Link';


### PR DESCRIPTION
## Summary
- add Link atom wrapping MUI Link with primary color and underline on hover
- export new atom
- document Link examples in Storybook
- add unit test

## Testing
- `pnpm run lint`
- `pnpm run test`


------
https://chatgpt.com/codex/tasks/task_e_684845c56efc832b96a0865f7e8a89ea