### PR TITLE
feat: add TextField atom

### DIFF
--- a/frontend/src/components/atoms/TextField.docs.mdx
+++ b/frontend/src/components/atoms/TextField.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './TextField.stories';
+import { TextField } from './TextField';
+
+<Meta of={Stories} />
+
+# TextField
+
+Campo de entrada de texto de una sola línea.
+
+<Story id="atoms-textfield--default" />
+
+<ArgsTable of={TextField} story="Default" />

--- a/frontend/src/components/atoms/TextField.stories.tsx
+++ b/frontend/src/components/atoms/TextField.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { TextField } from './TextField';
+
+const meta: Meta<typeof TextField> = {
+  title: 'Atoms/TextField',
+  component: TextField,
+  args: {
+    label: 'Nombre',
+  },
+  argTypes: {
+    onChange: { action: 'changed' },
+    value: { control: 'text' },
+    helperText: { control: 'text' },
+    error: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+    autoFocus: { control: 'boolean' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof TextField>;
+
+export const Default: Story = {};
+
+export const Filled: Story = {
+  args: { value: 'Juan' },
+};
+
+export const Focused: Story = {
+  args: { autoFocus: true },
+};
+
+export const Error: Story = {
+  args: { error: true, helperText: 'Campo obligatorio' },
+};
+
+export const Disabled: Story = {
+  args: { disabled: true },
+};

--- a/frontend/src/components/atoms/TextField.test.tsx
+++ b/frontend/src/components/atoms/TextField.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TextField } from './TextField';
+import { ThemeProvider } from '../../theme';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('TextField', () => {
+  it('renders label', () => {
+    renderWithTheme(<TextField label="Nombre" />);
+    expect(screen.getByLabelText(/nombre/i)).toBeInTheDocument();
+  });
+
+  it('shows value and calls onChange', async () => {
+    const user = userEvent.setup();
+    const handleChange = jest.fn();
+    renderWithTheme(<TextField label="Nombre" value="Juan" onChange={handleChange} />);
+    const input = screen.getByLabelText(/nombre/i) as HTMLInputElement;
+    expect(input.value).toBe('Juan');
+    await user.type(input, 'p');
+    expect(handleChange).toHaveBeenCalled();
+  });
+
+  it('renders helper text in error state', () => {
+    renderWithTheme(<TextField label="Nombre" error helperText="Campo requerido" />);
+    expect(screen.getByText('Campo requerido')).toBeInTheDocument();
+    const input = screen.getByLabelText(/nombre/i);
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('renders disabled state', async () => {
+    const handleChange = jest.fn();
+    renderWithTheme(<TextField label="Nombre" disabled onChange={handleChange} />);
+    const input = screen.getByLabelText(/nombre/i);
+    expect(input).toBeDisabled();
+    await userEvent.type(input, 'a');
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/atoms/TextField.tsx
+++ b/frontend/src/components/atoms/TextField.tsx
@@ -1,0 +1,18 @@
+import MuiTextField, {
+  TextFieldProps as MuiTextFieldProps,
+} from '@mui/material/TextField';
+
+export type TextFieldProps = MuiTextFieldProps;
+
+/**
+ * Campo de texto de una sola línea basado en MUI `TextField`.
+ */
+export function TextField({
+  variant = 'outlined',
+  fullWidth = true,
+  ...props
+}: TextFieldProps) {
+  return <MuiTextField variant={variant} fullWidth={fullWidth} {...props} />;
+}
+
+export default TextField;

--- a/frontend/src/components/atoms/index.ts
+++ b/frontend/src/components/atoms/index.ts
@@ -4,3 +4,4 @@ export { SecondaryButton } from './SecondaryButton';
 export { TertiaryButton } from './TertiaryButton';
 export { IconButton } from './IconButton';
 export { Link } from './Link';
+export { TextField } from './TextField';


### PR DESCRIPTION
## Summary
- add TextField atom using MUI
- document TextField in Storybook with MDX
- provide stories for common states
- test TextField behaviour
- re-export TextField from atoms index

## Testing
- `pnpm --filter ./frontend lint`
- `pnpm --filter ./frontend test`

------
https://chatgpt.com/codex/tasks/task_e_684849166598832bbee308e53c3a45df