### PR TITLE
Add TextArea atom

### DIFF
--- a/frontend/src/components/atoms/TextArea.docs.mdx
+++ b/frontend/src/components/atoms/TextArea.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './TextArea.stories';
+import { TextArea } from './TextArea';
+
+<Meta of={Stories} />
+
+# TextArea
+
+Campo de texto de múltiples líneas para comentarios o descripciones.
+
+<Story id="atoms-textarea--empty" />
+
+<ArgsTable of={TextArea} story="Empty" />

--- a/frontend/src/components/atoms/TextArea.stories.tsx
+++ b/frontend/src/components/atoms/TextArea.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { TextArea } from './TextArea';
+
+const meta: Meta<typeof TextArea> = {
+  title: 'Atoms/TextArea',
+  component: TextArea,
+  args: {
+    label: 'Descripción',
+  },
+  argTypes: {
+    onChange: { action: 'changed' },
+    value: { control: 'text' },
+    helperText: { control: 'text' },
+    error: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+    autoFocus: { control: 'boolean' },
+    resizable: { control: 'boolean' },
+    rows: { control: 'number' },
+    minRows: { control: 'number' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof TextArea>;
+
+export const Empty: Story = {};
+
+export const WithText: Story = {
+  args: {
+    value: 'L\u00ednea 1\nL\u00ednea 2\nL\u00ednea 3',
+  },
+};
+
+export const Error: Story = {
+  args: {
+    error: true,
+    helperText: 'Descripci\u00f3n requerida',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+};

--- a/frontend/src/components/atoms/TextArea.test.tsx
+++ b/frontend/src/components/atoms/TextArea.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TextArea } from './TextArea';
+import { ThemeProvider } from '../../theme';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('TextArea', () => {
+  it('renders textarea element with label', () => {
+    renderWithTheme(<TextArea label="Descripción" />);
+    const textarea = screen.getByLabelText(/descripción/i) as HTMLTextAreaElement;
+    expect(textarea.tagName).toBe('TEXTAREA');
+  });
+
+  it('shows value and calls onChange', async () => {
+    const user = userEvent.setup();
+    const handleChange = jest.fn();
+    renderWithTheme(
+      <TextArea label="Descripción" value="Texto" onChange={handleChange} />,
+    );
+    const textarea = screen.getByLabelText(/descripción/i) as HTMLTextAreaElement;
+    expect(textarea.value).toBe('Texto');
+    await user.type(textarea, ' adicional');
+    expect(handleChange).toHaveBeenCalled();
+  });
+
+  it('renders helper text in error state', () => {
+    renderWithTheme(
+      <TextArea label="Descripción" error helperText="Campo requerido" />,
+    );
+    expect(screen.getByText('Campo requerido')).toBeInTheDocument();
+    const textarea = screen.getByLabelText(/descripción/i);
+    expect(textarea).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('renders disabled state', async () => {
+    const handleChange = jest.fn();
+    renderWithTheme(
+      <TextArea label="Descripción" disabled onChange={handleChange} />,
+    );
+    const textarea = screen.getByLabelText(/descripción/i);
+    expect(textarea).toBeDisabled();
+    await userEvent.type(textarea, 'a');
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/atoms/TextArea.tsx
+++ b/frontend/src/components/atoms/TextArea.tsx
@@ -1,0 +1,43 @@
+import MuiTextField, {
+  TextFieldProps as MuiTextFieldProps,
+} from '@mui/material/TextField';
+
+export interface TextAreaProps extends MuiTextFieldProps {
+  /**
+   * Permite que el usuario redimensione manualmente el área de texto.
+   * Si `false`, se aplica `resize: none`.
+   */
+  resizable?: boolean;
+}
+
+/**
+ * Campo de texto multilínea basado en MUI `TextField`.
+ */
+export function TextArea({
+  variant = 'outlined',
+  fullWidth = true,
+  multiline = true,
+  minRows = 3,
+  resizable = false,
+  InputProps,
+  ...props
+}: TextAreaProps) {
+  return (
+    <MuiTextField
+      variant={variant}
+      fullWidth={fullWidth}
+      multiline={multiline}
+      minRows={minRows}
+      InputProps={{
+        ...InputProps,
+        sx: {
+          '& textarea': { resize: resizable ? 'vertical' : 'none' },
+          ...InputProps?.sx,
+        },
+      }}
+      {...props}
+    />
+  );
+}
+
+export default TextArea;

--- a/frontend/src/components/atoms/index.ts
+++ b/frontend/src/components/atoms/index.ts
@@ -5,3 +5,4 @@ export { TertiaryButton } from './TertiaryButton';
 export { IconButton } from './IconButton';
 export { Link } from './Link';
 export { TextField } from './TextField';
+export { TextArea } from './TextArea';


### PR DESCRIPTION
## Summary
- create TextArea atom based on MUI TextField
- document new atom in Storybook
- add unit tests for TextArea
- export TextArea from atoms index

## Testing
- `pnpm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68484dc3b4f8832bae0e6d6f1761fdfc