### PR TITLE
fix(storybook): alias utils path for node

### DIFF
--- a/frontend/.storybook/main.js
+++ b/frontend/.storybook/main.js
@@ -6,6 +6,11 @@ export default {
     options: {},
   },
   webpackFinal: async (config) => {
+    config.resolve = config.resolve || {};
+    config.resolve.alias = {
+      ...(config.resolve.alias || {}),
+      '@mui/material/utils': '@mui/material/utils/index.js',
+    };
     config.module.rules.push({
       test: /\.(ts|tsx)$/,
       use: [


### PR DESCRIPTION
## Summary
- add Webpack alias for `@mui/material/utils` to prevent Node.js ESM resolution errors

## Testing
- `pnpm install`
- `pnpm test`
- `pnpm storybook --no-open --quiet` *(fails: WARN Module not found: Error: Can't resolve '@storybook/test')*

------
https://chatgpt.com/codex/tasks/task_e_68486769f888832b840038b82a64486a