### PR TITLE
feat(atoms): add Select component

### DIFF
--- a/frontend/src/components/atoms/Select.docs.mdx
+++ b/frontend/src/components/atoms/Select.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './Select.stories';
+import { Select } from './Select';
+
+<Meta of={Stories} />
+
+# Select
+
+Componente de lista desplegable para escoger una opción.
+
+<Story id="atoms-select--default" />
+
+<ArgsTable of={Select} story="Default" />

--- a/frontend/src/components/atoms/Select.stories.tsx
+++ b/frontend/src/components/atoms/Select.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Select } from './Select';
+
+const meta: Meta<typeof Select> = {
+  title: 'Atoms/Select',
+  component: Select,
+  args: {
+    label: 'Estado',
+    options: [
+      { value: 'a', label: 'Opcion A' },
+      { value: 'b', label: 'Opcion B' },
+      { value: 'c', label: 'Opcion C' },
+    ],
+    value: 'a',
+  },
+  argTypes: {
+    onChange: { action: 'changed' },
+    value: { control: 'text' },
+    error: { control: 'boolean' },
+    helperText: { control: 'text' },
+    disabled: { control: 'boolean' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Select>;
+
+export const Default: Story = {};
+
+export const Disabled: Story = {
+  args: { disabled: true },
+};
+
+export const Error: Story = {
+  args: { error: true, helperText: 'Campo requerido' },
+};

--- a/frontend/src/components/atoms/Select.test.tsx
+++ b/frontend/src/components/atoms/Select.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Select } from './Select';
+import { ThemeProvider } from '../../theme';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('Select', () => {
+  const options = [
+    { value: 'a', label: 'Opción A' },
+    { value: 'b', label: 'Opción B' },
+  ];
+
+  it('renders label and selected option', () => {
+    renderWithTheme(
+      <Select label="Estado" options={options} value="a" onChange={() => {}} />,
+    );
+    const select = screen.getByLabelText(/estado/i);
+    expect(select).toHaveTextContent('Opción A');
+  });
+
+  it('calls onChange when selecting another option', async () => {
+    const user = userEvent.setup();
+    const handleChange = jest.fn();
+    renderWithTheme(
+      <Select
+        label="Estado"
+        options={options}
+        value="a"
+        onChange={handleChange}
+      />,
+    );
+    const button = screen.getByLabelText(/estado/i);
+    fireEvent.mouseDown(button);
+    await user.click(screen.getByRole('option', { name: 'Opción B' }));
+    expect(handleChange).toHaveBeenCalled();
+    const event = handleChange.mock.calls[0][0];
+    expect(event.target.value).toBe('b');
+  });
+
+  it('renders helper text in error state', () => {
+    renderWithTheme(
+      <Select
+        label="Estado"
+        options={options}
+        value="a"
+        error
+        helperText="Requerido"
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.getByText('Requerido')).toBeInTheDocument();
+    const select = screen.getByLabelText(/estado/i);
+    expect(select).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('renders disabled state', async () => {
+    const handleChange = jest.fn();
+    renderWithTheme(
+      <Select
+        label="Estado"
+        options={options}
+        value="a"
+        disabled
+        onChange={handleChange}
+      />,
+    );
+    const button = screen.getByLabelText(/estado/i);
+    expect(button).toHaveAttribute('aria-disabled', 'true');
+    fireEvent.mouseDown(button);
+    expect(screen.queryByRole('option')).not.toBeInTheDocument();
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/atoms/Select.tsx
+++ b/frontend/src/components/atoms/Select.tsx
@@ -1,0 +1,80 @@
+import {
+  FormControl,
+  InputLabel,
+  Select as MuiSelect,
+  MenuItem,
+  SelectChangeEvent,
+  FormHelperText,
+  SelectProps as MuiSelectProps,
+} from '@mui/material';
+import { useId, ReactNode } from 'react';
+
+export interface SelectOption {
+  value: string | number;
+  label: string;
+  disabled?: boolean;
+}
+
+export interface SelectProps
+  extends Omit<MuiSelectProps, 'onChange' | 'value'> {
+  /** Etiqueta del campo. */
+  label?: string;
+  /** Opciones a mostrar en el menú desplegable. */
+  options: SelectOption[];
+  /** Valor seleccionado. */
+  value: string | number;
+  /** Manejador al cambiar la selección. */
+  onChange: (
+    event: SelectChangeEvent<string | number>,
+    child: ReactNode,
+  ) => void;
+  /** Mensaje de ayuda o error. */
+  helperText?: ReactNode;
+}
+
+/**
+ * Lista desplegable basada en MUI `Select`.
+ */
+export function Select({
+  label,
+  options,
+  value,
+  onChange,
+  error = false,
+  disabled = false,
+  helperText,
+  ...props
+}: SelectProps) {
+  const labelId = useId();
+
+  return (
+    <FormControl
+      fullWidth
+      variant="outlined"
+      disabled={disabled}
+      error={error}
+    >
+      {label && <InputLabel id={labelId}>{label}</InputLabel>}
+      <MuiSelect
+        labelId={labelId}
+        label={label}
+        value={value}
+        onChange={onChange}
+        {...props}
+      >
+        {options.map((option) => (
+          <MenuItem
+            key={option.value}
+            value={option.value}
+            disabled={option.disabled}
+          >
+            {option.label}
+          </MenuItem>
+        ))}
+      </MuiSelect>
+      {helperText && <FormHelperText>{helperText}</FormHelperText>}
+    </FormControl>
+  );
+}
+
+export default Select;

--- a/frontend/src/components/atoms/index.ts
+++ b/frontend/src/components/atoms/index.ts
@@ -6,3 +6,4 @@ export { IconButton } from './IconButton';
 export { Link } from './Link';
 export { TextField } from './TextField';
 export { TextArea } from './TextArea';
+export { Select } from './Select';


### PR DESCRIPTION
## Summary
- implement Select atom using MUI
- add Storybook stories and MDX docs
- add unit tests
- export from atoms index

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68486dd64630832ba9fa625d3eff0c6d