### PR TITLE
feat(atoms): add Slider component

### DIFF
--- a/frontend/src/components/atoms/Slider.docs.mdx
+++ b/frontend/src/components/atoms/Slider.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './Slider.stories';
+import { Slider } from './Slider';
+
+<Meta of={Stories} />
+
+# Slider
+
+Control deslizante para seleccionar un valor dentro de un rango.
+
+<Story id="atoms-slider--default" />
+
+<ArgsTable of={Slider} story="Default" />

--- a/frontend/src/components/atoms/Slider.stories.tsx
+++ b/frontend/src/components/atoms/Slider.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Slider } from './Slider';
+
+const meta: Meta<typeof Slider> = {
+  title: 'Atoms/Slider',
+  component: Slider,
+  args: {
+    value: 30,
+    min: 0,
+    max: 100,
+    step: 1,
+  },
+  argTypes: {
+    onChange: { action: 'changed' },
+    value: { control: 'object' },
+    marks: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Slider>;
+
+export const Default: Story = {};
+
+export const Disabled: Story = {
+  args: { disabled: true },
+};
+
+export const Range: Story = {
+  args: { value: [20, 80] },
+};
+
+export const WithMarks: Story = {
+  args: { marks: true },
+};

--- a/frontend/src/components/atoms/Slider.test.tsx
+++ b/frontend/src/components/atoms/Slider.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Slider } from './Slider';
+import { ThemeProvider } from '../../theme';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('Slider', () => {
+  it('renders with correct aria attributes', () => {
+    renderWithTheme(<Slider value={30} min={0} max={100} onChange={() => {}} />);
+    const slider = screen.getByRole('slider');
+    expect(slider).toHaveAttribute('aria-valuenow', '30');
+    expect(slider).toHaveAttribute('aria-valuemin', '0');
+    expect(slider).toHaveAttribute('aria-valuemax', '100');
+  });
+
+  it('calls onChange when pressing arrow key', () => {
+    const handleChange = jest.fn();
+    renderWithTheme(
+      <Slider value={30} min={0} max={100} step={1} onChange={handleChange} />,
+    );
+    const slider = screen.getByRole('slider');
+    fireEvent.keyDown(slider, { key: 'ArrowRight' });
+    expect(handleChange).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/atoms/Slider.tsx
+++ b/frontend/src/components/atoms/Slider.tsx
@@ -1,0 +1,12 @@
+import MuiSlider, { SliderProps as MuiSliderProps } from '@mui/material/Slider';
+
+export type SliderProps = MuiSliderProps;
+
+/**
+ * Control deslizante para seleccionar un valor o rango basado en MUI `Slider`.
+ */
+export function Slider({ color = 'primary', ...props }: SliderProps) {
+  return <MuiSlider color={color} {...props} />;
+}
+
+export default Slider;

--- a/frontend/src/components/atoms/index.ts
+++ b/frontend/src/components/atoms/index.ts
@@ -7,3 +7,4 @@ export { Link } from './Link';
 export { TextField } from './TextField';
 export { TextArea } from './TextArea';
 export { Select } from './Select';
+export { Slider } from './Slider';


### PR DESCRIPTION
## Summary
- implement Slider atom using MUI
- document Slider stories and MDX docs
- add unit tests for Slider
- export Slider from atoms index

## Testing
- `pnpm --filter ./frontend lint`
- `pnpm --filter ./frontend test`

------
https://chatgpt.com/codex/tasks/task_e_684871791dc8832bb568ca46bd116bf7