### PR TITLE
Fix slider storybook interactivity

### DIFF
--- a/frontend/src/components/atoms/Slider.docs.mdx
+++ b/frontend/src/components/atoms/Slider.docs.mdx
@@ -8,6 +8,9 @@ import { Slider } from './Slider';
 
 Control deslizante para seleccionar un valor dentro de un rango.
 
+Para un control no controlado utiliza `defaultValue`. Si usas la prop
+`value` debes actualizarla en `onChange` para que el deslizador se mueva.
+
 <Story id="atoms-slider--default" />
 
 <ArgsTable of={Slider} story="Default" />

--- a/frontend/src/components/atoms/Slider.stories.tsx
+++ b/frontend/src/components/atoms/Slider.stories.tsx
@@ -5,7 +5,7 @@ const meta: Meta<typeof Slider> = {
   title: 'Atoms/Slider',
   component: Slider,
   args: {
-    value: 30,
+    defaultValue: 30,
     min: 0,
     max: 100,
     step: 1,
@@ -13,6 +13,7 @@ const meta: Meta<typeof Slider> = {
   argTypes: {
     onChange: { action: 'changed' },
     value: { control: 'object' },
+    defaultValue: { control: 'object' },
     marks: { control: 'boolean' },
     disabled: { control: 'boolean' },
   },
@@ -28,7 +29,7 @@ export const Disabled: Story = {
 };
 
 export const Range: Story = {
-  args: { value: [20, 80] },
+  args: { defaultValue: [20, 80] },
 };
 
 export const WithMarks: Story = {


### PR DESCRIPTION
## Summary
- make Slider stories uncontrolled so they update on drag
- document the need to update value on `onChange`

## Testing
- `pnpm test` in `frontend`
- `pytest -q` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_6848a2b884ec832bba613f248ea2efba