### PR TITLE
feat(atoms): add Icon component

### DIFF
--- a/frontend/src/components/atoms/Icon.docs.mdx
+++ b/frontend/src/components/atoms/Icon.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './Icon.stories';
+import { Icon } from './Icon';
+
+<Meta of={Stories} />
+
+# Icon
+
+Representa un pictograma tomado de la librería Material Icons.
+
+<Story id="atoms-icon--gallery" />
+
+<ArgsTable of={Icon} story="Basic" />

--- a/frontend/src/components/atoms/Icon.stories.tsx
+++ b/frontend/src/components/atoms/Icon.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Icon, IconName } from './Icon';
+
+const meta: Meta<typeof Icon> = {
+  title: 'Atoms/Icon',
+  component: Icon,
+  args: {
+    name: 'search' as IconName,
+  },
+  argTypes: {
+    name: {
+      control: 'select',
+      options: ['search', 'user', 'settings', 'menu', 'close', 'delete', 'favorite'],
+    },
+    color: {
+      control: 'select',
+      options: ['inherit', 'primary', 'secondary', 'error', 'info'],
+    },
+    size: {
+      control: 'select',
+      options: ['inherit', 'small', 'medium', 'large'],
+    },
+    icon: { control: false },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Icon>;
+
+export const Basic: Story = {};
+
+export const Gallery: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: 16, alignItems: 'center' }}>
+      <Icon name="search" />
+      <Icon name="user" />
+      <Icon name="settings" />
+      <Icon name="menu" />
+      <Icon name="close" />
+      <Icon name="delete" color="error" />
+      <Icon name="favorite" color="secondary" />
+    </div>
+  ),
+};

--- a/frontend/src/components/atoms/Icon.test.tsx
+++ b/frontend/src/components/atoms/Icon.test.tsx
@@ -1,0 +1,32 @@
+import { render } from '@testing-library/react';
+import { Icon } from './Icon';
+import { ThemeProvider } from '../../theme';
+import SearchIcon from '@mui/icons-material/Search';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('Icon', () => {
+  it('renders icon by name', () => {
+    const { container } = renderWithTheme(<Icon name="search" data-testid="icon" />);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+  });
+
+  it('applies color and size classes', () => {
+    const { container } = renderWithTheme(
+      <Icon name="search" color="error" size="small" data-testid="icon" />,
+    );
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveClass('MuiSvgIcon-colorError');
+    expect(svg).toHaveClass('MuiSvgIcon-fontSizeSmall');
+  });
+
+  it('renders custom icon element', () => {
+    const { getByTestId } = renderWithTheme(
+      <Icon icon={<SearchIcon data-testid="custom" />} />,
+    );
+    expect(getByTestId('custom')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/atoms/Icon.tsx
+++ b/frontend/src/components/atoms/Icon.tsx
@@ -1,0 +1,52 @@
+import { ReactElement, cloneElement } from 'react';
+import type { SvgIconProps } from '@mui/material/SvgIcon';
+import SearchIcon from '@mui/icons-material/Search';
+import PersonIcon from '@mui/icons-material/Person';
+import SettingsIcon from '@mui/icons-material/Settings';
+import MenuIcon from '@mui/icons-material/Menu';
+import CloseIcon from '@mui/icons-material/Close';
+import DeleteIcon from '@mui/icons-material/Delete';
+import FavoriteIcon from '@mui/icons-material/Favorite';
+
+const ICONS = {
+  search: SearchIcon,
+  user: PersonIcon,
+  settings: SettingsIcon,
+  menu: MenuIcon,
+  close: CloseIcon,
+  delete: DeleteIcon,
+  favorite: FavoriteIcon,
+};
+
+export type IconName = keyof typeof ICONS;
+
+export interface IconProps extends Omit<SvgIconProps, 'fontSize'> {
+  /** Nombre del ícono predefinido. */
+  name?: IconName;
+  /** Ícono personalizado. Tiene prioridad sobre `name`. */
+  icon?: ReactElement<SvgIconProps>;
+  /** Tamaño del ícono. */
+  size?: 'inherit' | 'small' | 'medium' | 'large';
+}
+
+/**
+ * Representa un pictograma basado en Material Icons.
+ */
+export function Icon({
+  name,
+  icon,
+  size = 'medium',
+  color = 'inherit',
+  ...props
+}: IconProps) {
+  if (icon) {
+    return cloneElement(icon, { fontSize: size, color, ...props });
+  }
+
+  const IconComponent = name ? ICONS[name] : undefined;
+  return IconComponent ? (
+    <IconComponent fontSize={size} color={color} {...props} />
+  ) : null;
+}
+
+export default Icon;

--- a/frontend/src/components/atoms/index.ts
+++ b/frontend/src/components/atoms/index.ts
@@ -8,3 +8,4 @@ export { TextField } from './TextField';
 export { TextArea } from './TextArea';
 export { Select } from './Select';
 export { Slider } from './Slider';
+export { Icon } from './Icon';


### PR DESCRIPTION
## Summary
- create Icon atom to render Material Icons consistently
- document Icon usage in Storybook
- add tests for Icon
- export Icon from atoms index

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6848c0ccd1c4832ba228563da352f952