### PR TITLE
Add Avatar atom

### DIFF
--- a/frontend/src/components/atoms/Avatar.docs.mdx
+++ b/frontend/src/components/atoms/Avatar.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './Avatar.stories';
+import { Avatar } from './Avatar';
+
+<Meta of={Stories} />
+
+# Avatar
+
+Muestra la imagen de perfil o iniciales de un usuario.
+
+<Story id="atoms-avatar--image" />
+
+<ArgsTable of={Avatar} story="Image" />

--- a/frontend/src/components/atoms/Avatar.stories.tsx
+++ b/frontend/src/components/atoms/Avatar.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Avatar } from './Avatar';
+
+const meta: Meta<typeof Avatar> = {
+  title: 'Atoms/Avatar',
+  component: Avatar,
+  args: {
+    src: 'https://i.pravatar.cc/40',
+    alt: 'Foto de usuario',
+    size: 'medium',
+  },
+  argTypes: {
+    src: { control: 'text' },
+    alt: { control: 'text' },
+    variant: { control: 'select', options: ['circular', 'rounded', 'square'] },
+    size: { control: 'select', options: ['small', 'medium', 'large'] },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Avatar>;
+
+export const Image: Story = {};
+
+export const Initials: Story = {
+  args: { src: undefined, children: 'AB' },
+};
+
+export const Rounded: Story = {
+  args: { variant: 'rounded' },
+};
+
+export const Large: Story = {
+  args: { size: 'large' },
+};

--- a/frontend/src/components/atoms/Avatar.test.tsx
+++ b/frontend/src/components/atoms/Avatar.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import { Avatar } from './Avatar';
+import { ThemeProvider } from '../../theme';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('Avatar', () => {
+  it('renders image with alt text', () => {
+    renderWithTheme(<Avatar src="avatar.png" alt="Foto de Juan" />);
+    const img = screen.getByRole('img', { name: /foto de juan/i });
+    expect(img).toHaveAttribute('src', 'avatar.png');
+  });
+
+  it('renders initials when no image', () => {
+    renderWithTheme(<Avatar>JP</Avatar>);
+    expect(screen.getByText('JP')).toBeInTheDocument();
+  });
+
+  it('applies variant class', () => {
+    const { container } = renderWithTheme(<Avatar variant="rounded">JP</Avatar>);
+    const root = container.firstChild as HTMLElement;
+    expect(root).toHaveClass('MuiAvatar-rounded');
+  });
+
+  it('applies size styles', () => {
+    const { getByText } = renderWithTheme(<Avatar size="large">JP</Avatar>);
+    const root = getByText('JP');
+    expect(root).toHaveStyle({ width: '64px', height: '64px' });
+  });
+});

--- a/frontend/src/components/atoms/Avatar.tsx
+++ b/frontend/src/components/atoms/Avatar.tsx
@@ -1,0 +1,24 @@
+import MuiAvatar, { AvatarProps as MuiAvatarProps } from '@mui/material/Avatar';
+
+const SIZE_MAP = {
+  small: 32,
+  medium: 40,
+  large: 64,
+} as const;
+
+export interface AvatarProps extends MuiAvatarProps {
+  /** Tamaño predefinido del avatar. */
+  size?: keyof typeof SIZE_MAP;
+}
+
+/**
+ * Muestra la imagen o iniciales de un usuario en forma circular por defecto.
+ */
+export function Avatar({ size, sx, ...props }: AvatarProps) {
+  const dimension = size ? SIZE_MAP[size] : undefined;
+  const sxProp = dimension ? { width: dimension, height: dimension, ...sx } : sx;
+
+  return <MuiAvatar sx={sxProp} {...props} />;
+}
+
+export default Avatar;

--- a/frontend/src/components/atoms/index.ts
+++ b/frontend/src/components/atoms/index.ts
@@ -9,3 +9,4 @@ export { TextArea } from './TextArea';
 export { Select } from './Select';
 export { Slider } from './Slider';
 export { Icon } from './Icon';
+export { Avatar } from './Avatar';


### PR DESCRIPTION
## Summary
- implement `Avatar` atom based on MUI Avatar
- add storybook stories and docs
- include unit tests
- export new component

## Testing
- `pnpm --filter ./frontend lint`
- `pnpm --filter ./frontend test`


------
https://chatgpt.com/codex/tasks/task_e_6848f47c213c832bb1fe1427fe1c07d8