### PR TITLE
feat(atoms): add Badge component

### DIFF
--- a/src/components/atoms/Badge.stories.mdx
+++ b/src/components/atoms/Badge.stories.mdx
@@ -1,0 +1,14 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import { Badge } from './Badge';
+import * as Stories from './Badge.stories';
+
+<Meta of={Stories} />
+
+# Badge
+
+Small indicator for counts or status. It wraps another element and displays
+content like numbers or dots in a corner.
+
+<Story id="atoms-badge--default" />
+
+<ArgsTable of={Badge} story="Default" />

--- a/src/components/atoms/Badge.stories.tsx
+++ b/src/components/atoms/Badge.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import NotificationsIcon from '@mui/icons-material/Notifications';
+import { Badge } from './Badge';
+
+const meta: Meta<typeof Badge> = {
+  title: 'Atoms/Badge',
+  component: Badge,
+  args: {
+    content: 5,
+    children: <NotificationsIcon />,
+    color: 'error',
+  },
+  argTypes: {
+    children: { control: false },
+    content: { control: 'text' },
+    color: {
+      control: 'select',
+      options: ['primary', 'secondary', 'error', 'info', 'success', 'warning'],
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Badge>;
+
+export const Default: Story = {};
+
+export const Overflow: Story = {
+  args: { content: 100, max: 99 },
+};
+
+export const ShowZero: Story = {
+  args: { content: 0, showZero: true },
+};
+
+export const Dot: Story = {
+  args: { variant: 'dot', content: 0 },
+};

--- a/src/components/atoms/Badge.test.tsx
+++ b/src/components/atoms/Badge.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Badge } from './Badge';
+
+test('renders number content', () => {
+  render(
+    <Badge content={5}>
+      <span>icon</span>
+    </Badge>
+  );
+  expect(screen.getByText('5')).toBeInTheDocument();
+});
+
+test('applies max and shows overflow', () => {
+  render(
+    <Badge content={100} max={99}>
+      <span>icon</span>
+    </Badge>
+  );
+  expect(screen.getByText('99+')).toBeInTheDocument();
+});
+
+test('hides zero when showZero is false', () => {
+  render(
+    <Badge content={0}>
+      <span>icon</span>
+    </Badge>
+  );
+  expect(screen.queryByText('0')).not.toBeInTheDocument();
+});
+
+test('shows zero when showZero is true', () => {
+  render(
+    <Badge content={0} showZero>
+      <span>icon</span>
+    </Badge>
+  );
+  expect(screen.getByText('0')).toBeInTheDocument();
+});

--- a/src/components/atoms/Badge.tsx
+++ b/src/components/atoms/Badge.tsx
@@ -1,0 +1,25 @@
+import MUIBadge, { type BadgeProps as MUIBadgeProps } from '@mui/material/Badge';
+import { type ReactNode } from 'react';
+
+export interface BadgeProps
+  extends Omit<MUIBadgeProps, 'badgeContent' | 'color' | 'children'> {
+  /** Content to display inside the badge */
+  content: ReactNode;
+  /** Element the badge is anchored to */
+  children: ReactNode;
+  /** Badge color (defaults to "error") */
+  color?: MUIBadgeProps['color'];
+}
+
+export const Badge = ({
+  content,
+  children,
+  color = 'error',
+  ...props
+}: BadgeProps) => (
+  <MUIBadge badgeContent={content} color={color} {...props}>
+    {children}
+  </MUIBadge>
+);
+
+export default Badge;

--- a/src/components/atoms/index.ts
+++ b/src/components/atoms/index.ts
@@ -1,1 +1,2 @@
 export { SecondaryButton } from './SecondaryButton';
+export { Badge } from './Badge';


### PR DESCRIPTION
## Summary
- create atomic Badge component
- add unit tests for Badge
- document Badge usage in Storybook
- export Badge from atoms index

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a294d8698832ba4acb1cc74d7d0e0