### PR TITLE
feat(atoms): add Badge component

### DIFF
--- a/frontend/src/components/atoms/Badge.docs.mdx
+++ b/frontend/src/components/atoms/Badge.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './Badge.stories';
+import { Badge } from './Badge';
+
+<Meta of={Stories} />
+
+# Badge
+
+Indicador pequeño para mostrar conteos o estados sobre un elemento.
+
+<Story id="atoms-badge--default" />
+
+<ArgsTable of={Badge} story="Default" />

--- a/frontend/src/components/atoms/Badge.stories.tsx
+++ b/frontend/src/components/atoms/Badge.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import MailIcon from '@mui/icons-material/Mail';
+import { Badge } from './Badge';
+
+const meta: Meta<typeof Badge> = {
+  title: 'Atoms/Badge',
+  component: Badge,
+  args: {
+    content: 5,
+    children: <MailIcon />,
+  },
+  argTypes: {
+    content: { control: 'number' },
+    color: {
+      control: 'select',
+      options: ['primary', 'secondary', 'error', 'info', 'success', 'warning'],
+    },
+    max: { control: 'number' },
+    showZero: { control: 'boolean' },
+    variant: { control: 'select', options: ['standard', 'dot'] },
+    children: { control: false },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Badge>;
+
+export const Default: Story = {};
+
+export const ZeroHidden: Story = {
+  args: { content: 0, showZero: false },
+};
+
+export const ZeroVisible: Story = {
+  args: { content: 0, showZero: true },
+};
+
+export const DotVariant: Story = {
+  args: { variant: 'dot', content: 0 },
+};
+
+export const Overflow: Story = {
+  args: { content: 120, max: 99 },
+};

--- a/frontend/src/components/atoms/Badge.test.tsx
+++ b/frontend/src/components/atoms/Badge.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from '@testing-library/react';
+import { Badge } from './Badge';
+import { ThemeProvider } from '../../theme';
+import MailIcon from '@mui/icons-material/Mail';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('Badge', () => {
+  it('renders badge content', () => {
+    renderWithTheme(
+      <Badge content={5}>
+        <MailIcon />
+      </Badge>,
+    );
+    expect(screen.getByText('5')).toBeInTheDocument();
+  });
+
+  it('applies color class', () => {
+    const { container } = renderWithTheme(
+      <Badge content={1} color="primary">
+        <MailIcon />
+      </Badge>,
+    );
+    const badge = container.querySelector('.MuiBadge-badge') as HTMLElement;
+    expect(badge).toHaveClass('MuiBadge-colorPrimary');
+  });
+
+  it('respects max prop', () => {
+    renderWithTheme(
+      <Badge content={100} max={99}>
+        <MailIcon />
+      </Badge>,
+    );
+    expect(screen.getByText('99+')).toBeInTheDocument();
+  });
+
+  it('hides badge when content is zero by default', () => {
+    const { container } = renderWithTheme(
+      <Badge content={0}>
+        <MailIcon />
+      </Badge>,
+    );
+    const badge = container.querySelector('.MuiBadge-badge') as HTMLElement;
+    expect(badge).toHaveClass('MuiBadge-invisible');
+    expect(screen.queryByText('0')).not.toBeInTheDocument();
+  });
+
+  it('shows zero when showZero is true', () => {
+    renderWithTheme(
+      <Badge content={0} showZero>
+        <MailIcon />
+      </Badge>,
+    );
+    expect(screen.getByText('0')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/atoms/Badge.tsx
+++ b/frontend/src/components/atoms/Badge.tsx
@@ -1,0 +1,22 @@
+import MuiBadge, { BadgeProps as MuiBadgeProps } from '@mui/material/Badge';
+import { ReactNode } from 'react';
+
+export interface BadgeProps extends Omit<MuiBadgeProps, 'badgeContent' | 'color'> {
+  /** Contenido a mostrar dentro de la banda. */
+  content: ReactNode;
+  /** Color de la badge. */
+  color?: MuiBadgeProps['color'];
+}
+
+/**
+ * Pequeño indicador superpuesto para notificaciones o conteos.
+ */
+export function Badge({ content, children, color = 'error', ...props }: BadgeProps) {
+  return (
+    <MuiBadge badgeContent={content} color={color} {...props}>
+      {children}
+    </MuiBadge>
+  );
+}
+
+export default Badge;

--- a/frontend/src/components/atoms/index.ts
+++ b/frontend/src/components/atoms/index.ts
@@ -10,3 +10,4 @@ export { Select } from './Select';
 export { Slider } from './Slider';
 export { Icon } from './Icon';
 export { Avatar } from './Avatar';
+export { Badge } from './Badge';


### PR DESCRIPTION
## Summary
- implement `Badge` atom using MUI
- document Badge usage in Storybook
- add unit tests for Badge
- export Badge from atoms index

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_684a4031e8a0832bacd4e66f6bbc8d93