### PR TITLE
feat(atoms): add Chip component

### DIFF
--- a/frontend/src/components/atoms/Chip.docs.mdx
+++ b/frontend/src/components/atoms/Chip.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './Chip.stories';
+import { Chip } from './Chip';
+
+<Meta of={Stories} />
+
+# Chip
+
+Pequeño elemento para mostrar etiquetas o estados.
+
+<Story id="atoms-chip--basic" />
+
+<ArgsTable of={Chip} story="Basic" />

--- a/frontend/src/components/atoms/Chip.stories.tsx
+++ b/frontend/src/components/atoms/Chip.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Chip } from './Chip';
+import FaceIcon from '@mui/icons-material/Face';
+
+const meta: Meta<typeof Chip> = {
+  title: 'Atoms/Chip',
+  component: Chip,
+  args: {
+    label: 'Etiqueta',
+  },
+  argTypes: {
+    onClick: { action: 'clicked' },
+    onDelete: { action: 'deleted' },
+    icon: { control: false },
+    avatar: { control: false },
+    color: {
+      control: 'select',
+      options: [
+        'default',
+        'primary',
+        'secondary',
+        'error',
+        'info',
+        'success',
+        'warning',
+      ],
+    },
+    variant: { control: 'select', options: ['filled', 'outlined'] },
+    disabled: { control: 'boolean' },
+    clickable: { control: false },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Chip>;
+
+export const Basic: Story = {};
+
+export const Clickable: Story = {
+  args: { onClick: () => {}, color: 'primary' },
+};
+
+export const Deletable: Story = {
+  args: { onDelete: () => {} },
+};
+
+export const ClickableDeletable: Story = {
+  args: { onClick: () => {}, onDelete: () => {}, color: 'secondary' },
+};
+
+export const WithIcon: Story = {
+  args: { icon: <FaceIcon /> },
+};
+
+export const Disabled: Story = {
+  args: { disabled: true, onClick: () => {} },
+};
+
+export const Outlined: Story = {
+  args: { variant: 'outlined' },
+};

--- a/frontend/src/components/atoms/Chip.test.tsx
+++ b/frontend/src/components/atoms/Chip.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Chip } from './Chip';
+import { ThemeProvider } from '../../theme';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('Chip', () => {
+  it('renders the label', () => {
+    renderWithTheme(<Chip label="Etiqueta" />);
+    expect(screen.getByText('Etiqueta')).toBeInTheDocument();
+  });
+
+  it('calls onClick when clicked', async () => {
+    const user = userEvent.setup();
+    const handleClick = jest.fn();
+    renderWithTheme(<Chip label="Etiqueta" onClick={handleClick} />);
+    await user.click(screen.getByRole('button', { name: /etiqueta/i }));
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onDelete when delete icon clicked', async () => {
+    const user = userEvent.setup();
+    const handleDelete = jest.fn();
+    const { container } = renderWithTheme(<Chip label="Tag" onDelete={handleDelete} />);
+    const icon = container.querySelector('.MuiChip-deleteIcon') as HTMLElement;
+    await user.click(icon);
+    expect(handleDelete).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders disabled state', () => {
+    const handleClick = jest.fn();
+    renderWithTheme(<Chip label="Dis" disabled onClick={handleClick} />);
+    const chip = screen.getByRole('button', { name: /dis/i });
+    expect(chip).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('applies color class when color prop used', () => {
+    const { container } = renderWithTheme(<Chip label="color" color="primary" />);
+    const chip = container.firstChild as HTMLElement;
+    expect(chip).toHaveClass('MuiChip-colorPrimary');
+  });
+
+  it('applies outlined variant', () => {
+    const { container } = renderWithTheme(<Chip label="outline" variant="outlined" />);
+    const chip = container.firstChild as HTMLElement;
+    expect(chip).toHaveClass('MuiChip-outlined');
+  });
+});

--- a/frontend/src/components/atoms/Chip.tsx
+++ b/frontend/src/components/atoms/Chip.tsx
@@ -1,0 +1,12 @@
+import MuiChip, { ChipProps as MuiChipProps } from '@mui/material/Chip';
+
+export type ChipProps = MuiChipProps;
+
+/**
+ * Pequeño elemento para representar etiquetas o estados.
+ */
+export function Chip({ variant = 'filled', color = 'default', ...props }: ChipProps) {
+  return <MuiChip variant={variant} color={color} {...props} />;
+}
+
+export default Chip;

--- a/frontend/src/components/atoms/index.ts
+++ b/frontend/src/components/atoms/index.ts
@@ -11,3 +11,4 @@ export { Slider } from './Slider';
 export { Icon } from './Icon';
 export { Avatar } from './Avatar';
 export { Badge } from './Badge';
+export { Chip } from './Chip';


### PR DESCRIPTION
## Summary
- implement Chip atom using MUI `Chip`
- add Storybook stories and docs
- provide unit tests
- export new atom in components index

## Testing
- `pnpm --filter erp-frontend lint`
- `pnpm --filter erp-frontend test`

------
https://chatgpt.com/codex/tasks/task_e_684a55d3bf9c832bad2f1854a6088386