### PR TITLE
Add Tooltip atom

### DIFF
--- a/frontend/src/components/atoms/Tooltip.docs.mdx
+++ b/frontend/src/components/atoms/Tooltip.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './Tooltip.stories';
+import { Tooltip } from './Tooltip';
+
+<Meta of={Stories} />
+
+# Tooltip
+
+Elemento informativo que aparece al pasar el cursor o enfocar el objetivo.
+
+<Story id="atoms-tooltip--default" />
+
+<ArgsTable of={Tooltip} story="Default" />

--- a/frontend/src/components/atoms/Tooltip.stories.tsx
+++ b/frontend/src/components/atoms/Tooltip.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import InfoIcon from '@mui/icons-material/Info';
+import { Tooltip } from './Tooltip';
+import { IconButton } from './IconButton';
+
+const meta: Meta<typeof Tooltip> = {
+  title: 'Atoms/Tooltip',
+  component: Tooltip,
+  args: {
+    title: 'Texto explicativo',
+    placement: 'bottom',
+    arrow: true,
+    children: <IconButton icon={<InfoIcon />} aria-label="info" />,
+  },
+  argTypes: {
+    title: { control: 'text' },
+    placement: {
+      control: 'select',
+      options: ['bottom', 'top', 'right', 'left'],
+    },
+    arrow: { control: 'boolean' },
+    children: { control: false },
+    open: { control: false },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Tooltip>;
+
+export const Default: Story = {};
+
+export const RightPlacement: Story = {
+  args: { placement: 'right' },
+};
+
+export const WithoutArrow: Story = {
+  args: { arrow: false },
+};

--- a/frontend/src/components/atoms/Tooltip.test.tsx
+++ b/frontend/src/components/atoms/Tooltip.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Tooltip } from './Tooltip';
+import { ThemeProvider } from '../../theme';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('Tooltip', () => {
+  it('shows tooltip text on hover', async () => {
+    const user = userEvent.setup();
+    renderWithTheme(
+      <Tooltip title="Info">
+        <button>Trigger</button>
+      </Tooltip>,
+    );
+    await user.hover(screen.getByText('Trigger'));
+    expect(await screen.findByText('Info')).toBeInTheDocument();
+  });
+
+  it('shows tooltip on focus', async () => {
+    const user = userEvent.setup();
+    renderWithTheme(
+      <Tooltip title="Focus text">
+        <button>Btn</button>
+      </Tooltip>,
+    );
+    const btn = screen.getByText('Btn');
+    await user.tab();
+    expect(btn).toHaveFocus();
+    expect(await screen.findByText('Focus text')).toBeInTheDocument();
+  });
+
+  it('applies placement and arrow', () => {
+    renderWithTheme(
+      <Tooltip title="Test" placement="right" arrow open>
+        <button>Icon</button>
+      </Tooltip>,
+    );
+    const tooltip = screen.getByRole('tooltip');
+    expect(tooltip).toHaveAttribute('data-popper-placement', 'right');
+    expect(tooltip.querySelector('.MuiTooltip-arrow')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/atoms/Tooltip.tsx
+++ b/frontend/src/components/atoms/Tooltip.tsx
@@ -1,0 +1,32 @@
+import MuiTooltip, { TooltipProps as MuiTooltipProps } from '@mui/material/Tooltip';
+import { ReactElement } from 'react';
+
+export interface TooltipProps extends Omit<MuiTooltipProps, 'title' | 'children'> {
+  /** Texto o elemento a mostrar dentro del tooltip */
+  title: MuiTooltipProps['title'];
+  /** Elemento objetivo que recibe el tooltip */
+  children: ReactElement;
+  /** Posición del tooltip respecto al elemento */
+  placement?: MuiTooltipProps['placement'];
+  /** Muestra una flecha apuntando al elemento */
+  arrow?: boolean;
+}
+
+/**
+ * Tooltip informativo que envuelve a un elemento objetivo.
+ */
+export function Tooltip({
+  title,
+  children,
+  placement = 'bottom',
+  arrow = true,
+  ...props
+}: TooltipProps) {
+  return (
+    <MuiTooltip title={title} placement={placement} arrow={arrow} {...props}>
+      {children}
+    </MuiTooltip>
+  );
+}
+
+export default Tooltip;

--- a/frontend/src/components/atoms/index.ts
+++ b/frontend/src/components/atoms/index.ts
@@ -12,3 +12,4 @@ export { Icon } from './Icon';
 export { Avatar } from './Avatar';
 export { Badge } from './Badge';
 export { Chip } from './Chip';
+export { Tooltip } from './Tooltip';


### PR DESCRIPTION
## Summary
- implement `Tooltip` atom wrapping MUI Tooltip
- document new component with MDX
- add Storybook stories and RTL tests
- export Tooltip from atoms index

## Testing
- `pnpm --filter ./frontend test`

------
https://chatgpt.com/codex/tasks/task_e_684b35436bd0832bb954d7aec981567c