### PR TITLE
Implement Alert atom

### DIFF
--- a/frontend/src/components/atoms/Alert.docs.mdx
+++ b/frontend/src/components/atoms/Alert.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './Alert.stories';
+import { Alert } from './Alert';
+
+<Meta of={Stories} />
+
+# Alert
+
+Indicador visual de información, éxito, advertencia o error.
+
+<Story id="atoms-alert--info" />
+
+<ArgsTable of={Alert} story="Info" />

--- a/frontend/src/components/atoms/Alert.stories.tsx
+++ b/frontend/src/components/atoms/Alert.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Alert } from './Alert';
+
+const meta: Meta<typeof Alert> = {
+  title: 'Atoms/Alert',
+  component: Alert,
+  args: {
+    severity: 'info',
+    children: 'Información relevante para el usuario.',
+  },
+  argTypes: {
+    onClose: { action: 'closed' },
+    severity: {
+      control: 'select',
+      options: ['error', 'warning', 'info', 'success'],
+    },
+    variant: {
+      control: 'select',
+      options: ['standard', 'outlined', 'filled'],
+    },
+    title: { control: 'text' },
+    children: { control: 'text' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Alert>;
+
+export const Info: Story = {};
+export const Success: Story = {
+  args: { severity: 'success', children: 'Operación exitosa.' },
+};
+export const Warning: Story = {
+  args: { severity: 'warning', children: 'Atención: revise los datos.' },
+};
+export const Error: Story = {
+  args: { severity: 'error', children: 'Ha ocurrido un error.' },
+};
+export const Closable: Story = {
+  args: {
+    severity: 'info',
+    onClose: () => {},
+    children: 'Puede descartar esta alerta.',
+  },
+};
+export const WithTitle: Story = {
+  args: {
+    severity: 'error',
+    title: 'Error',
+    children: 'Ocurrió un problema al guardar.',
+  },
+};
+export const Filled: Story = {
+  args: { severity: 'success', variant: 'filled', children: 'Acción completada.' },
+};

--- a/frontend/src/components/atoms/Alert.test.tsx
+++ b/frontend/src/components/atoms/Alert.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Alert } from './Alert';
+import { ThemeProvider } from '../../theme';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('Alert', () => {
+  it('renders message text', () => {
+    renderWithTheme(<Alert severity="error">Mensaje de error</Alert>);
+    expect(screen.getByText('Mensaje de error')).toBeInTheDocument();
+  });
+
+  it('renders close button and calls onClose', async () => {
+    const user = userEvent.setup();
+    const handleClose = jest.fn();
+    renderWithTheme(
+      <Alert severity="error" onClose={handleClose}>
+        Cerrar
+      </Alert>,
+    );
+    const button = screen.getByRole('button', { name: /close/i });
+    await user.click(button);
+    expect(handleClose).toHaveBeenCalled();
+  });
+
+  it('does not render close button when onClose is absent', () => {
+    renderWithTheme(<Alert severity="info">Info</Alert>);
+    expect(screen.queryByRole('button', { name: /close/i })).not.toBeInTheDocument();
+  });
+
+  it('applies severity and variant classes', () => {
+    const { container } = renderWithTheme(
+      <Alert severity="success" variant="outlined">
+        Ok
+      </Alert>,
+    );
+    const root = container.firstChild as HTMLElement;
+    expect(root).toHaveClass('MuiAlert-outlinedSuccess');
+  });
+
+  it('renders title when provided', () => {
+    renderWithTheme(
+      <Alert severity="error" title="Error:">
+        Falló
+      </Alert>,
+    );
+    expect(screen.getByText('Error:')).toBeInTheDocument();
+    expect(screen.getByText('Falló')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/atoms/Alert.tsx
+++ b/frontend/src/components/atoms/Alert.tsx
@@ -1,0 +1,32 @@
+import MuiAlert, { AlertProps as MuiAlertProps } from '@mui/material/Alert';
+import MuiAlertTitle from '@mui/material/AlertTitle';
+import { PropsWithChildren, ReactNode } from 'react';
+
+export interface AlertProps extends Omit<MuiAlertProps, 'children'> {
+  /** Texto principal de la alerta. Puede usarse en lugar de `children`. */
+  message?: ReactNode;
+  /** Título opcional mostrado en negrita antes del contenido. */
+  title?: ReactNode;
+}
+
+/**
+ * Mensaje informativo para estados de error, éxito o advertencia.
+ */
+export function Alert({
+  severity = 'info',
+  variant = 'standard',
+  onClose,
+  message,
+  title,
+  children,
+  ...props
+}: PropsWithChildren<AlertProps>) {
+  return (
+    <MuiAlert severity={severity} variant={variant} onClose={onClose} {...props}>
+      {title && <MuiAlertTitle>{title}</MuiAlertTitle>}
+      {children ?? message}
+    </MuiAlert>
+  );
+}
+
+export default Alert;

--- a/frontend/src/components/atoms/index.ts
+++ b/frontend/src/components/atoms/index.ts
@@ -13,3 +13,4 @@ export { Avatar } from './Avatar';
 export { Badge } from './Badge';
 export { Chip } from './Chip';
 export { Tooltip } from './Tooltip';
+export { Alert } from './Alert';


### PR DESCRIPTION
## Summary
- implement `Alert` atom for MUI alerts
- document the component in Storybook
- add tests
- export from atoms index

## Testing
- `pnpm --filter ./frontend lint` *(fails: ESLint couldn't find config)*
- `pnpm --filter ./frontend test`

------
https://chatgpt.com/codex/tasks/task_e_684ba3656568832b99ac345d747660cd