### PR TITLE
feat(ui): add Snackbar atom

### DIFF
--- a/frontend/src/components/atoms/Snackbar.docs.mdx
+++ b/frontend/src/components/atoms/Snackbar.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './Snackbar.stories';
+import { Snackbar } from './Snackbar';
+
+<Meta of={Stories} />
+
+# Snackbar
+
+Mensaje temporal para notificaciones breves.
+
+<Story id="atoms-snackbar--default" />
+
+<ArgsTable of={Snackbar} story="Default" />

--- a/frontend/src/components/atoms/Snackbar.stories.tsx
+++ b/frontend/src/components/atoms/Snackbar.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Snackbar } from './Snackbar';
+import { PrimaryButton } from './PrimaryButton';
+
+const meta: Meta<typeof Snackbar> = {
+  title: 'Atoms/Snackbar',
+  component: Snackbar,
+  args: {
+    open: true,
+    message: 'Cambios guardados',
+    autoHideDuration: 3000,
+  },
+  argTypes: {
+    onClose: { action: 'closed' },
+    message: { control: 'text' },
+    autoHideDuration: { control: 'number' },
+    action: { control: false },
+    anchorOrigin: { control: false },
+    open: { control: 'boolean' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Snackbar>;
+
+export const Default: Story = {};
+
+export const WithAction: Story = {
+  args: {
+    action: <PrimaryButton size="small">DESHACER</PrimaryButton>,
+  },
+};

--- a/frontend/src/components/atoms/Snackbar.test.tsx
+++ b/frontend/src/components/atoms/Snackbar.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen, waitForElementToBeRemoved } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Snackbar } from './Snackbar';
+import { ThemeProvider } from '../../theme';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('Snackbar', () => {
+  it('renders message when open', () => {
+    renderWithTheme(<Snackbar open message="Guardado" />);
+    expect(screen.getByText('Guardado')).toBeInTheDocument();
+  });
+
+  it('hides message when open becomes false', async () => {
+    const { rerender } = renderWithTheme(<Snackbar open message="Ok" />);
+    expect(screen.getByText('Ok')).toBeInTheDocument();
+    rerender(
+      <ThemeProvider>
+        <Snackbar open={false} message="Ok" />
+      </ThemeProvider>,
+    );
+    await waitForElementToBeRemoved(() => screen.queryByText('Ok'));
+  });
+
+  it('calls action handler when clicked', async () => {
+    const user = userEvent.setup();
+    const handleClick = jest.fn();
+    renderWithTheme(
+      <Snackbar
+        open
+        message="Hecho"
+        action={<button onClick={handleClick}>UNDO</button>}
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: /undo/i }));
+    expect(handleClick).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/atoms/Snackbar.tsx
+++ b/frontend/src/components/atoms/Snackbar.tsx
@@ -1,0 +1,39 @@
+import MuiSnackbar, { SnackbarProps as MuiSnackbarProps } from '@mui/material/Snackbar';
+import { ReactNode } from 'react';
+
+export interface SnackbarProps
+  extends Omit<MuiSnackbarProps, 'message' | 'anchorOrigin' | 'autoHideDuration'> {
+  /** Texto a mostrar dentro del snackbar */
+  message: ReactNode;
+  /** Posición del snackbar en pantalla */
+  anchorOrigin?: MuiSnackbarProps['anchorOrigin'];
+  /** Tiempo en milisegundos antes de ocultar automáticamente */
+  autoHideDuration?: number;
+}
+
+/**
+ * Mensaje temporal que se muestra en la parte inferior de la pantalla.
+ */
+export function Snackbar({
+  message,
+  open,
+  onClose,
+  autoHideDuration = 3000,
+  anchorOrigin = { vertical: 'bottom', horizontal: 'center' },
+  action,
+  ...props
+}: SnackbarProps) {
+  return (
+    <MuiSnackbar
+      open={open}
+      message={message}
+      onClose={onClose}
+      autoHideDuration={autoHideDuration}
+      anchorOrigin={anchorOrigin}
+      action={action}
+      {...props}
+    />
+  );
+}
+
+export default Snackbar;

--- a/frontend/src/components/atoms/index.ts
+++ b/frontend/src/components/atoms/index.ts
@@ -14,3 +14,4 @@ export { Badge } from './Badge';
 export { Chip } from './Chip';
 export { Tooltip } from './Tooltip';
 export { Alert } from './Alert';
+export { Snackbar } from './Snackbar';


### PR DESCRIPTION
## Summary
- implement Snackbar atom using MUI
- document snackbar props in Storybook
- add MDX docs for Snackbar
- test Snackbar behaviour
- export Snackbar from atoms index

## Testing
- `npm run lint --silent`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684c7f13376c832ba4a58621b1f024d9