### PR TITLE
Add Switch atom

### DIFF
--- a/frontend/src/components/atoms/Switch.docs.mdx
+++ b/frontend/src/components/atoms/Switch.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './Switch.stories';
+import { Switch } from './Switch';
+
+<Meta of={Stories} />
+
+# Switch
+
+Interruptor para opciones binarias. Acompaña siempre con una etiqueta visible o `aria-label` para accesibilidad.
+
+<Story id="atoms-switch--off" />
+
+<ArgsTable of={Switch} story="Off" />

--- a/frontend/src/components/atoms/Switch.stories.tsx
+++ b/frontend/src/components/atoms/Switch.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Switch } from './Switch';
+
+const meta: Meta<typeof Switch> = {
+  title: 'Atoms/Switch',
+  component: Switch,
+  args: {
+    checked: false,
+  },
+  argTypes: {
+    onChange: { action: 'changed' },
+    checked: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+    color: {
+      control: 'select',
+      options: ['primary', 'secondary', 'error', 'info', 'default'],
+    },
+    size: { control: 'select', options: ['medium', 'small'] },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Switch>;
+
+export const Off: Story = {};
+export const On: Story = { args: { checked: true } };
+export const Disabled: Story = { args: { disabled: true } };
+export const Secondary: Story = {
+  args: { color: 'secondary', checked: true },
+};
+export const Small: Story = {
+  args: { size: 'small' },
+};

--- a/frontend/src/components/atoms/Switch.test.tsx
+++ b/frontend/src/components/atoms/Switch.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Switch } from './Switch';
+import { ThemeProvider } from '../../theme';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('Switch', () => {
+  it('reflects checked prop and calls onChange', () => {
+    const handleChange = jest.fn();
+    renderWithTheme(<Switch checked={false} onChange={handleChange} />);
+    const input = screen.getByRole('checkbox') as HTMLInputElement;
+    expect(input.checked).toBe(false);
+    fireEvent.click(input);
+    expect(handleChange).toHaveBeenCalled();
+  });
+
+  it('renders checked state', () => {
+    renderWithTheme(<Switch checked onChange={() => {}} />);
+    const input = screen.getByRole('checkbox') as HTMLInputElement;
+    expect(input.checked).toBe(true);
+  });
+
+  it('is disabled when disabled prop true', () => {
+    const handleChange = jest.fn();
+    renderWithTheme(<Switch checked disabled onChange={handleChange} />);
+    const input = screen.getByRole('checkbox') as HTMLInputElement;
+    expect(input).toBeDisabled();
+    input.click();
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/atoms/Switch.tsx
+++ b/frontend/src/components/atoms/Switch.tsx
@@ -1,0 +1,12 @@
+import MuiSwitch, { SwitchProps as MuiSwitchProps } from '@mui/material/Switch';
+
+export type SwitchProps = MuiSwitchProps;
+
+/**
+ * Control de activación/desactivación basado en MUI `Switch`.
+ */
+export function Switch({ color = 'primary', ...props }: SwitchProps) {
+  return <MuiSwitch color={color} {...props} />;
+}
+
+export default Switch;

--- a/frontend/src/components/atoms/index.ts
+++ b/frontend/src/components/atoms/index.ts
@@ -15,3 +15,4 @@ export { Chip } from './Chip';
 export { Tooltip } from './Tooltip';
 export { Alert } from './Alert';
 export { Snackbar } from './Snackbar';
+export { Switch } from './Switch';


### PR DESCRIPTION
## Summary
- implement `Switch` atom using MUI
- document Switch behaviour in Storybook
- add stories and tests
- export new component

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684c8f6b2384832b865335f74764f930