### PR TITLE
feat(atoms): add Checkbox component

### DIFF
--- a/frontend/src/components/atoms/Checkbox.docs.mdx
+++ b/frontend/src/components/atoms/Checkbox.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './Checkbox.stories';
+import { Checkbox } from './Checkbox';
+
+<Meta of={Stories} />
+
+# Checkbox
+
+Casilla de selección para opciones booleanas. Se recomienda acompañar con una etiqueta visible.
+
+<Story id="atoms-checkbox--unchecked" />
+
+<ArgsTable of={Checkbox} story="Unchecked" />

--- a/frontend/src/components/atoms/Checkbox.stories.tsx
+++ b/frontend/src/components/atoms/Checkbox.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Checkbox } from './Checkbox';
+
+const meta: Meta<typeof Checkbox> = {
+  title: 'Atoms/Checkbox',
+  component: Checkbox,
+  args: {
+    checked: false,
+  },
+  argTypes: {
+    onChange: { action: 'changed' },
+    checked: { control: 'boolean' },
+    indeterminate: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+    color: {
+      control: 'select',
+      options: ['primary', 'secondary', 'error', 'info', 'default'],
+    },
+    size: { control: 'select', options: ['medium', 'small'] },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Checkbox>;
+
+export const Unchecked: Story = {};
+export const Checked: Story = { args: { checked: true } };
+export const Indeterminate: Story = { args: { indeterminate: true } };
+export const Disabled: Story = { args: { disabled: true } };
+export const Secondary: Story = {
+  args: { color: 'secondary', checked: true },
+};
+export const Small: Story = { args: { size: 'small' } };

--- a/frontend/src/components/atoms/Checkbox.test.tsx
+++ b/frontend/src/components/atoms/Checkbox.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Checkbox } from './Checkbox';
+import { ThemeProvider } from '../../theme';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('Checkbox', () => {
+  it('reflects checked prop and calls onChange', () => {
+    const handleChange = jest.fn();
+    renderWithTheme(<Checkbox checked={false} onChange={handleChange} />);
+    const input = screen.getByRole('checkbox') as HTMLInputElement;
+    expect(input.checked).toBe(false);
+    fireEvent.click(input);
+    expect(handleChange).toHaveBeenCalled();
+  });
+
+  it('renders checked state', () => {
+    renderWithTheme(<Checkbox checked onChange={() => {}} />);
+    const input = screen.getByRole('checkbox') as HTMLInputElement;
+    expect(input.checked).toBe(true);
+  });
+
+  it('shows indeterminate state', () => {
+    renderWithTheme(<Checkbox indeterminate onChange={() => {}} />);
+    const input = screen.getByRole('checkbox');
+    expect(input.getAttribute('data-indeterminate')).toBe('true');
+  });
+
+  it('is disabled when disabled prop true', () => {
+    const handleChange = jest.fn();
+    renderWithTheme(<Checkbox checked disabled onChange={handleChange} />);
+    const input = screen.getByRole('checkbox') as HTMLInputElement;
+    expect(input).toBeDisabled();
+    input.click();
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/atoms/Checkbox.tsx
+++ b/frontend/src/components/atoms/Checkbox.tsx
@@ -1,0 +1,12 @@
+import MuiCheckbox, { CheckboxProps as MuiCheckboxProps } from '@mui/material/Checkbox';
+
+export type CheckboxProps = MuiCheckboxProps;
+
+/**
+ * Casilla de verificación basada en MUI `Checkbox`.
+ */
+export function Checkbox({ color = 'primary', ...props }: CheckboxProps) {
+  return <MuiCheckbox color={color} {...props} />;
+}
+
+export default Checkbox;

--- a/frontend/src/components/atoms/index.ts
+++ b/frontend/src/components/atoms/index.ts
@@ -16,3 +16,4 @@ export { Tooltip } from './Tooltip';
 export { Alert } from './Alert';
 export { Snackbar } from './Snackbar';
 export { Switch } from './Switch';
+export { Checkbox } from './Checkbox';


### PR DESCRIPTION
## Summary
- implement Checkbox atom leveraging MUI Checkbox
- document Checkbox usage in MDX and Storybook
- test Checkbox behavior
- export Checkbox from atoms index

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684cbafd683c832bbb4f81de0373f09f