### PR TITLE
feat(atoms): add RadioButton component

### DIFF
--- a/frontend/src/components/atoms/RadioButton.docs.mdx
+++ b/frontend/src/components/atoms/RadioButton.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './RadioButton.stories';
+import { RadioButton } from './RadioButton';
+
+<Meta of={Stories} />
+
+# RadioButton
+
+Permite seleccionar una opción dentro de un grupo. Asigna el mismo `name` a varios radios para que sean mutuamente excluyentes.
+
+<Story id="atoms-radiobutton--unchecked" />
+
+<ArgsTable of={RadioButton} story="Unchecked" />

--- a/frontend/src/components/atoms/RadioButton.stories.tsx
+++ b/frontend/src/components/atoms/RadioButton.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { RadioButton } from './RadioButton';
+
+const meta: Meta<typeof RadioButton> = {
+  title: 'Atoms/RadioButton',
+  component: RadioButton,
+  args: {
+    checked: false,
+  },
+  argTypes: {
+    onChange: { action: 'changed' },
+    checked: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+    color: {
+      control: 'select',
+      options: ['primary', 'secondary', 'error', 'info', 'default'],
+    },
+    size: { control: 'select', options: ['medium', 'small'] },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof RadioButton>;
+
+export const Unchecked: Story = {};
+export const Checked: Story = { args: { checked: true } };
+export const Disabled: Story = { args: { disabled: true } };
+export const Secondary: Story = {
+  args: { color: 'secondary', checked: true },
+};
+export const Small: Story = { args: { size: 'small' } };

--- a/frontend/src/components/atoms/RadioButton.test.tsx
+++ b/frontend/src/components/atoms/RadioButton.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { RadioButton } from './RadioButton';
+import { ThemeProvider } from '../../theme';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('RadioButton', () => {
+  it('reflects checked prop and calls onChange when clicked', () => {
+    const handleChange = jest.fn();
+    renderWithTheme(
+      <>
+        <RadioButton checked={false} value="op1" onChange={handleChange} />
+        <RadioButton checked value="op2" onChange={() => {}} />
+      </>,
+    );
+    const radios = screen.getAllByRole('radio') as HTMLInputElement[];
+    expect(radios[0].checked).toBe(false);
+    expect(radios[1].checked).toBe(true);
+    fireEvent.click(radios[0]);
+    expect(handleChange).toHaveBeenCalled();
+  });
+
+  it('is disabled when disabled prop true', () => {
+    const handleChange = jest.fn();
+    renderWithTheme(<RadioButton disabled onChange={handleChange} />);
+    const input = screen.getByRole('radio') as HTMLInputElement;
+    expect(input).toBeDisabled();
+    input.click();
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/atoms/RadioButton.tsx
+++ b/frontend/src/components/atoms/RadioButton.tsx
@@ -1,0 +1,12 @@
+import MuiRadio, { RadioProps as MuiRadioProps } from '@mui/material/Radio';
+
+export type RadioButtonProps = MuiRadioProps;
+
+/**
+ * Botón de opción basado en MUI `Radio`.
+ */
+export function RadioButton({ color = 'primary', ...props }: RadioButtonProps) {
+  return <MuiRadio color={color} {...props} />;
+}
+
+export default RadioButton;

--- a/frontend/src/components/atoms/index.ts
+++ b/frontend/src/components/atoms/index.ts
@@ -17,3 +17,4 @@ export { Alert } from './Alert';
 export { Snackbar } from './Snackbar';
 export { Switch } from './Switch';
 export { Checkbox } from './Checkbox';
+export { RadioButton } from './RadioButton';


### PR DESCRIPTION
## Summary
- implement `RadioButton` atom using MUI
- document RadioButton with Storybook stories and docs
- add unit tests
- export new atom

## Testing
- `pnpm -r --if-present lint`
- `pnpm -r --if-present test`
- `pip install -r requirements.txt -r requirements.dev.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684cca8a8754832b8208757e6a966fbc