### PR TITLE
feat(frontend): add FormField molecule with Label atom

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,8 @@ docs(agents): aclara flujo de revisión para IA Codex
 | Storybook | toda nueva prop documentada con MDX & Controls |
 | Tests | React Testing Library + Jest (≥ 80 % lines) |
 
+> Antes de crear una molécula revisa los átomos existentes y reutiliza el más cercano. Si no hay un átomo equivalente, crea uno nuevo siguiendo la estructura de `atoms/`.
+
 ### 4. Back-end
 * **FastAPI** “REST-first”; versión en ruta `/api/v1/*`.
 * **Pydantic v2** para validación; usa `field_validators` cuando aplique.
@@ -58,4 +60,4 @@ docs(agents): aclara flujo de revisión para IA Codex
 ---
 
 > **Actualiza este documento** cada vez que cambie una norma o se añada tooling nuevo.  
-> Última revisión: 2025-06-08
+> Última revisión: 2025-06-14

--- a/frontend/src/components/atoms/Label.docs.mdx
+++ b/frontend/src/components/atoms/Label.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './Label.stories';
+import { Label } from './Label';
+
+<Meta of={Stories} />
+
+# Label
+
+Etiqueta de formulario basada en MUI `FormLabel`.
+
+<Story id="atoms-label--default" />
+
+<ArgsTable of={Label} story="Default" />

--- a/frontend/src/components/atoms/Label.stories.tsx
+++ b/frontend/src/components/atoms/Label.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Label } from './Label';
+
+const meta: Meta<typeof Label> = {
+  title: 'Atoms/Label',
+  component: Label,
+  args: {
+    htmlFor: 'input',
+    children: 'Nombre',
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Label>;
+
+export const Default: Story = {};

--- a/frontend/src/components/atoms/Label.test.tsx
+++ b/frontend/src/components/atoms/Label.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react';
+import { Label } from './Label';
+import { ThemeProvider } from '../../theme';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('Label', () => {
+  it('renders text', () => {
+    renderWithTheme(<Label htmlFor="name">Nombre</Label>);
+    expect(screen.getByText('Nombre')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/atoms/Label.tsx
+++ b/frontend/src/components/atoms/Label.tsx
@@ -1,0 +1,12 @@
+import FormLabel, { FormLabelProps } from '@mui/material/FormLabel';
+
+export type LabelProps = FormLabelProps;
+
+/**
+ * Etiqueta para campos de formulario basada en MUI `FormLabel`.
+ */
+export function Label(props: LabelProps) {
+  return <FormLabel {...props} />;
+}
+
+export default Label;

--- a/frontend/src/components/atoms/index.ts
+++ b/frontend/src/components/atoms/index.ts
@@ -18,3 +18,4 @@ export { Snackbar } from './Snackbar';
 export { Switch } from './Switch';
 export { Checkbox } from './Checkbox';
 export { RadioButton } from './RadioButton';
+export { Label } from './Label';

--- a/frontend/src/components/molecules/FormField/FormField.docs.mdx
+++ b/frontend/src/components/molecules/FormField/FormField.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './FormField.stories';
+import { FormField } from './FormField';
+
+<Meta of={Stories} />
+
+# FormField
+
+Combina un `Label` con un `TextField` para crear un campo de formulario completo.
+
+<Story id="molecules-formfield--default" />
+
+<ArgsTable of={FormField} story="Default" />

--- a/frontend/src/components/molecules/FormField/FormField.stories.tsx
+++ b/frontend/src/components/molecules/FormField/FormField.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { FormField } from './FormField';
+
+const meta: Meta<typeof FormField> = {
+  title: 'Molecules/FormField',
+  component: FormField,
+  args: {
+    label: 'Nombre',
+    placeholder: 'Ingresa tu nombre',
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof FormField>;
+
+export const Default: Story = {};
+
+export const Error: Story = {
+  args: {
+    error: true,
+    errorMessage: 'Campo requerido',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+    value: 'Texto',
+  },
+};

--- a/frontend/src/components/molecules/FormField/FormField.test.tsx
+++ b/frontend/src/components/molecules/FormField/FormField.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from '../../../theme';
+import { FormField } from './FormField';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('FormField', () => {
+  it('renders label associated with input', () => {
+    renderWithTheme(<FormField label="Nombre" />);
+    const input = screen.getByLabelText('Nombre');
+    expect(input).toBeInTheDocument();
+  });
+
+  it('calls onChange when typing', async () => {
+    const user = userEvent.setup();
+    const handleChange = jest.fn();
+    renderWithTheme(<FormField label="Nombre" onChange={handleChange} />);
+    const input = screen.getByLabelText('Nombre') as HTMLInputElement;
+    await user.type(input, 'Juan');
+    expect(handleChange).toHaveBeenCalled();
+  });
+
+  it('shows error message and styles in error state', () => {
+    renderWithTheme(<FormField label="Nombre" error errorMessage="Campo requerido" />);
+    expect(screen.getByText('Campo requerido')).toBeInTheDocument();
+    const input = screen.getByLabelText('Nombre');
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+  });
+});

--- a/frontend/src/components/molecules/FormField/FormField.tsx
+++ b/frontend/src/components/molecules/FormField/FormField.tsx
@@ -1,0 +1,65 @@
+import { useId, useState } from 'react';
+import { Box, Typography } from '@mui/material';
+import { TextField, TextFieldProps, Label } from '../../atoms';
+
+export interface FormFieldProps extends Omit<TextFieldProps, 'label'> {
+  /** Texto de la etiqueta */
+  label: string;
+  /** Mensaje de error a mostrar */
+  errorMessage?: string;
+}
+
+/**
+ * Combina un `Label` con un `TextField` para formar un campo de formulario.
+ */
+export function FormField({
+  label,
+  id,
+  error = false,
+  errorMessage,
+  onFocus,
+  onBlur,
+  ...props
+}: FormFieldProps) {
+  const generatedId = useId();
+  const inputId = id ?? generatedId;
+  const [focused, setFocused] = useState(false);
+
+  const handleFocus: React.FocusEventHandler<HTMLInputElement> = (e) => {
+    setFocused(true);
+    onFocus?.(e);
+  };
+
+  const handleBlur: React.FocusEventHandler<HTMLInputElement> = (e) => {
+    setFocused(false);
+    onBlur?.(e);
+  };
+
+  return (
+    <Box display="flex" flexDirection="column" gap={0.5}>
+      <Label
+        htmlFor={inputId}
+        sx={{
+          mb: 0.5,
+          color: error ? 'error.main' : focused ? 'primary.main' : undefined,
+        }}
+      >
+        {label}
+      </Label>
+      <TextField
+        id={inputId}
+        error={error}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
+        {...props}
+      />
+      {error && errorMessage && (
+        <Typography variant="caption" color="error" data-testid="error-text">
+          {errorMessage}
+        </Typography>
+      )}
+    </Box>
+  );
+}
+
+export default FormField;

--- a/frontend/src/components/molecules/index.ts
+++ b/frontend/src/components/molecules/index.ts
@@ -1,0 +1,1 @@
+export { FormField } from './FormField/FormField';

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -1,1 +1,2 @@
 export * from './components/atoms';
+export * from './components/molecules';


### PR DESCRIPTION
## Summary
- update agent guidelines about using or creating atoms
- add `Label` atom
- create `FormField` molecule
- export new components
- provide stories and tests

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_684ccfaa375c832bb7c41dcaccff4dc7