### PR TITLE
feat(components): add LabeledTextField molecule

### DIFF
--- a/frontend/src/components/molecules/LabeledTextField.docs.mdx
+++ b/frontend/src/components/molecules/LabeledTextField.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './LabeledTextField.stories';
+import { LabeledTextField } from './LabeledTextField';
+
+<Meta of={Stories} />
+
+# LabeledTextField
+
+Campo de texto con una etiqueta visible asociada al input.
+
+<Story id="molecules-labeledtextfield--default" />
+
+<ArgsTable of={LabeledTextField} story="Default" />

--- a/frontend/src/components/molecules/LabeledTextField.stories.tsx
+++ b/frontend/src/components/molecules/LabeledTextField.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { LabeledTextField } from './LabeledTextField';
+
+const meta: Meta<typeof LabeledTextField> = {
+  title: 'Molecules/LabeledTextField',
+  component: LabeledTextField,
+  args: {
+    label: 'Nombre',
+  },
+  argTypes: {
+    onChange: { action: 'changed' },
+    value: { control: 'text' },
+    helperText: { control: 'text' },
+    error: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+    autoFocus: { control: 'boolean' },
+    size: { control: 'radio', options: ['small', 'medium'] },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof LabeledTextField>;
+
+export const Default: Story = {};
+
+export const WithValue: Story = {
+  args: { value: 'Ejemplo' },
+};
+
+export const Disabled: Story = {
+  args: { disabled: true, value: 'Texto' },
+};
+
+export const Error: Story = {
+  args: { error: true, helperText: 'Campo requerido' },
+};
+
+export const Small: Story = {
+  args: { size: 'small' },
+};

--- a/frontend/src/components/molecules/LabeledTextField.test.tsx
+++ b/frontend/src/components/molecules/LabeledTextField.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from '../../theme';
+import { LabeledTextField } from './LabeledTextField';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('LabeledTextField', () => {
+  it('associates label and input', () => {
+    renderWithTheme(<LabeledTextField label="Nombre" />);
+    const input = screen.getByLabelText('Nombre');
+    expect(input).toBeInTheDocument();
+  });
+
+  it('updates value on change', async () => {
+    const user = userEvent.setup();
+    const handleChange = jest.fn();
+    renderWithTheme(<LabeledTextField label="Nombre" onChange={handleChange} />);
+    const input = screen.getByLabelText('Nombre') as HTMLInputElement;
+    await user.type(input, 'Juan');
+    expect(handleChange).toHaveBeenCalled();
+  });
+
+  it('renders disabled state', async () => {
+    const handleChange = jest.fn();
+    renderWithTheme(
+      <LabeledTextField label="Nombre" disabled onChange={handleChange} />,
+    );
+    const input = screen.getByLabelText('Nombre');
+    expect(input).toBeDisabled();
+    await userEvent.type(input, 'a');
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+
+  it('shows helper text in error state', () => {
+    renderWithTheme(
+      <LabeledTextField label="Nombre" error helperText="Campo requerido" />,
+    );
+    expect(screen.getByText('Campo requerido')).toBeInTheDocument();
+    const input = screen.getByLabelText('Nombre');
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+  });
+});

--- a/frontend/src/components/molecules/LabeledTextField.tsx
+++ b/frontend/src/components/molecules/LabeledTextField.tsx
@@ -1,0 +1,65 @@
+import { Box, Typography } from '@mui/material';
+import { useId, useState } from 'react';
+import { TextField, TextFieldProps } from '../atoms';
+
+export interface LabeledTextFieldProps extends Omit<TextFieldProps, 'label'> {
+  /** Texto de la etiqueta */
+  label: string;
+}
+
+/**
+ * Campo de texto con etiqueta visible. Combina un `TextField` y un `label` para
+ * conformar una unidad de formulario coherente.
+ */
+export function LabeledTextField({
+  label,
+  id,
+  size = 'medium',
+  error = false,
+  helperText,
+  disabled = false,
+  onFocus,
+  onBlur,
+  ...props
+}: LabeledTextFieldProps) {
+  const generatedId = useId();
+  const inputId = id ?? generatedId;
+  const [focused, setFocused] = useState(false);
+
+  const handleFocus: React.FocusEventHandler<HTMLInputElement> = (e) => {
+    setFocused(true);
+    onFocus?.(e);
+  };
+
+  const handleBlur: React.FocusEventHandler<HTMLInputElement> = (e) => {
+    setFocused(false);
+    onBlur?.(e);
+  };
+
+  return (
+    <Box display="flex" flexDirection="column" gap={0.5}>
+      <Typography
+        component="label"
+        htmlFor={inputId}
+        sx={{
+          mb: 0.5,
+          color: error ? 'error.main' : focused ? 'primary.main' : undefined,
+        }}
+      >
+        {label}
+      </Typography>
+      <TextField
+        id={inputId}
+        size={size}
+        error={error}
+        helperText={helperText}
+        disabled={disabled}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
+        {...props}
+      />
+    </Box>
+  );
+}
+
+export default LabeledTextField;

--- a/frontend/src/components/molecules/index.ts
+++ b/frontend/src/components/molecules/index.ts
@@ -1,0 +1,1 @@
+export { LabeledTextField } from './LabeledTextField';

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -1,1 +1,2 @@
 export * from './components/atoms';
+export * from './components/molecules';


### PR DESCRIPTION
## Summary
- implement `LabeledTextField` molecule composed of a label and text field
- document component in Storybook and add basic stories
- cover new molecule with unit tests
- export molecule from component index files

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684dbda191d8832b8dd84144bf808fc7