### PR TITLE
feat(components): add LabeledSelectField molecule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,16 +1,19 @@
 # Guía para Agentes / Desarrolladores
 
-## Propósito  
+## Propósito
+
 Unificar criterios de **arquitectura, estilo, seguridad y flujos de trabajo** para quienes colaboren (personas o IA). Si eres un agente autónomo, sigue esta referencia antes de escribir o modificar una sola línea de código.
 
 ---
 
 ### 1. Convenciones de commit (`Conventional Commits`)
+
 feat(ventas): soporte multi-moneda en checkout
 fix(inventario): corrige desbordamiento al reservar stock
 docs(agents): aclara flujo de revisión para IA Codex
 
 ### 2. Flujo Git
+
 1. **branch** = `<issue-id>-<slug>` → PR ↔ `develop`
 2. PR gatilla CI (lint + tests + build).
 3. Min. 1 review humano + 1 review IA (`/review`).
@@ -18,42 +21,48 @@ docs(agents): aclara flujo de revisión para IA Codex
 5. Ramas protegidas: `main` y `develop` requieren PR con CI verde.
 
 ### 3. Front-end
-| Requisito | Norma |
-|-----------|-------|
-| Componentes | Atomic Design (atoms → molecules → organisms → templates → pages) |
-| Styling | solo MUI v6 (`sx` / styled API); **nunca CSS suelto** |
-| Accesibilidad | score Lighthouse ≥ 90 (WCAG 2.2 AA) |
-| Storybook | toda nueva prop documentada con MDX & Controls |
-| Tests | React Testing Library + Jest (≥ 80 % lines) |
+
+| Requisito     | Norma                                                                                                                                                                           |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Componentes   | Atomic Design (atoms → molecules → organisms → templates → pages)                                                                                                               |
+| Jerarquía     | Las páginas se construyen a partir de módulos; un módulo agrupa múltiples componentes, cada componente se forma con organismos, los organismos con moléculas y éstas con átomos |
+| Styling       | solo MUI v6 (`sx` / styled API); **nunca CSS suelto**                                                                                                                           |
+| Accesibilidad | score Lighthouse ≥ 90 (WCAG 2.2 AA)                                                                                                                                             |
+| Storybook     | toda nueva prop documentada con MDX & Controls                                                                                                                                  |
+| Tests         | React Testing Library + Jest (≥ 80 % lines)                                                                                                                                     |
 
 ### 4. Back-end
-* **FastAPI** “REST-first”; versión en ruta `/api/v1/*`.
-* **Pydantic v2** para validación; usa `field_validators` cuando aplique.
-* DB **PostgreSQL** → SQLAlchemy 2 (async); migraciones = Alembic.
-* Seguridad: OAuth2 + JWT; hash de pass = `bcrypt`.
-* CORS activado solo para orígenes listados en `.env` (`ALLOWED_ORIGINS`).
-* Observabilidad OTel: cada request genera trace-id propagado a front.
-* Dependencias separadas: `requirements.txt` (runtime) y `requirements.dev.txt` (lint, tests, mypy).
+
+- **FastAPI** “REST-first”; versión en ruta `/api/v1/*`.
+- **Pydantic v2** para validación; usa `field_validators` cuando aplique.
+- DB **PostgreSQL** → SQLAlchemy 2 (async); migraciones = Alembic.
+- Seguridad: OAuth2 + JWT; hash de pass = `bcrypt`.
+- CORS activado solo para orígenes listados en `.env` (`ALLOWED_ORIGINS`).
+- Observabilidad OTel: cada request genera trace-id propagado a front.
+- Dependencias separadas: `requirements.txt` (runtime) y `requirements.dev.txt` (lint, tests, mypy).
 
 ### 5. Infra & Dev Ops
-* Docker: un proceso por contenedor; `docker-compose -f docker-compose.dev.yml up`.
-* CI = GitHub Actions: lint → tests → build Docker → push a ECR (staging).
-* Secrets via GitHub Secrets (nunca en el repo).
-* RPO ≤ 15 min, RTO ≤ 30 min (ver runbooks en `/docs/dr`).
-* Gestor Node = PNPM; habilita `corepack` para versiones homogéneas.
-* Dependabot alerts activos para actualizar dependencias de Node y Python.
+
+- Docker: un proceso por contenedor; `docker-compose -f docker-compose.dev.yml up`.
+- CI = GitHub Actions: lint → tests → build Docker → push a ECR (staging).
+- Secrets via GitHub Secrets (nunca en el repo).
+- RPO ≤ 15 min, RTO ≤ 30 min (ver runbooks en `/docs/dr`).
+- Gestor Node = PNPM; habilita `corepack` para versiones homogéneas.
+- Dependabot alerts activos para actualizar dependencias de Node y Python.
 
 ### 6. Estilo de código
-* **Python**: `ruff` + `black --line-length 88` + `isort`.
-* **TypeScript**: `eslint` base Airbnb + `prettier`.
-* Naming: snake_case en Python, camelCase en TS; nada de abreviaturas crípticas.
-* Comentarios: escribe **por qué**, no **qué**.
+
+- **Python**: `ruff` + `black --line-length 88` + `isort`.
+- **TypeScript**: `eslint` base Airbnb + `prettier`.
+- Naming: snake_case en Python, camelCase en TS; nada de abreviaturas crípticas.
+- Comentarios: escribe **por qué**, no **qué**.
 
 ### 7. IA Codex (este agente)
-* Respeta siempre esta guía y el backlog “Single Source of Truth”.
-* Antes de generar código, **razona**: ¿impacta seguridad? ¿escala?
-* Al crear componentes React: genera archivo `.stories.tsx` y prueba básica.
-* Al crear endpoint FastAPI: genera test con `TestClient`.
+
+- Respeta siempre esta guía y el backlog “Single Source of Truth”.
+- Antes de generar código, **razona**: ¿impacta seguridad? ¿escala?
+- Al crear componentes React: genera archivo `.stories.tsx` y prueba básica.
+- Al crear endpoint FastAPI: genera test con `TestClient`.
 
 ---
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,16 +1,19 @@
 # Guía para Agentes / Desarrolladores
 
-## Propósito  
+## Propósito
+
 Unificar criterios de **arquitectura, estilo, seguridad y flujos de trabajo** para quienes colaboren (personas o IA). Si eres un agente autónomo, sigue esta referencia antes de escribir o modificar una sola línea de código.
 
 ---
 
 ### 1. Convenciones de commit (`Conventional Commits`)
+
 feat(ventas): soporte multi-moneda en checkout
 fix(inventario): corrige desbordamiento al reservar stock
 docs(agents): aclara flujo de revisión para IA Codex
 
 ### 2. Flujo Git
+
 1. **branch** = `<issue-id>-<slug>` → PR ↔ `develop`
 2. PR gatilla CI (lint + tests + build).
 3. Min. 1 review humano + 1 review IA (`/review`).
@@ -18,42 +21,48 @@ docs(agents): aclara flujo de revisión para IA Codex
 5. Ramas protegidas: `main` y `develop` requieren PR con CI verde.
 
 ### 3. Front-end
-| Requisito | Norma |
-|-----------|-------|
-| Componentes | Atomic Design (atoms → molecules → organisms → templates → pages) |
-| Styling | solo MUI v6 (`sx` / styled API); **nunca CSS suelto** |
-| Accesibilidad | score Lighthouse ≥ 90 (WCAG 2.2 AA) |
-| Storybook | toda nueva prop documentada con MDX & Controls |
-| Tests | React Testing Library + Jest (≥ 80 % lines) |
+
+| Requisito     | Norma                                                                                                                                                                           |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Componentes   | Atomic Design (atoms → molecules → organisms → templates → pages)                                                                                                               |
+| Jerarquía     | Las páginas se construyen a partir de módulos; un módulo agrupa múltiples componentes, cada componente se forma con organismos, los organismos con moléculas y éstas con átomos |
+| Styling       | solo MUI v6 (`sx` / styled API); **nunca CSS suelto**                                                                                                                           |
+| Accesibilidad | score Lighthouse ≥ 90 (WCAG 2.2 AA)                                                                                                                                             |
+| Storybook     | toda nueva prop documentada con MDX & Controls                                                                                                                                  |
+| Tests         | React Testing Library + Jest (≥ 80 % lines)                                                                                                                                     |
 
 ### 4. Back-end
-* **FastAPI** “REST-first”; versión en ruta `/api/v1/*`.
-* **Pydantic v2** para validación; usa `field_validators` cuando aplique.
-* DB **PostgreSQL** → SQLAlchemy 2 (async); migraciones = Alembic.
-* Seguridad: OAuth2 + JWT; hash de pass = `bcrypt`.
-* CORS activado solo para orígenes listados en `.env` (`ALLOWED_ORIGINS`).
-* Observabilidad OTel: cada request genera trace-id propagado a front.
-* Dependencias separadas: `requirements.txt` (runtime) y `requirements.dev.txt` (lint, tests, mypy).
+
+- **FastAPI** “REST-first”; versión en ruta `/api/v1/*`.
+- **Pydantic v2** para validación; usa `field_validators` cuando aplique.
+- DB **PostgreSQL** → SQLAlchemy 2 (async); migraciones = Alembic.
+- Seguridad: OAuth2 + JWT; hash de pass = `bcrypt`.
+- CORS activado solo para orígenes listados en `.env` (`ALLOWED_ORIGINS`).
+- Observabilidad OTel: cada request genera trace-id propagado a front.
+- Dependencias separadas: `requirements.txt` (runtime) y `requirements.dev.txt` (lint, tests, mypy).
 
 ### 5. Infra & Dev Ops
-* Docker: un proceso por contenedor; `docker-compose -f docker-compose.dev.yml up`.
-* CI = GitHub Actions: lint → tests → build Docker → push a ECR (staging).
-* Secrets via GitHub Secrets (nunca en el repo).
-* RPO ≤ 15 min, RTO ≤ 30 min (ver runbooks en `/docs/dr`).
-* Gestor Node = PNPM; habilita `corepack` para versiones homogéneas.
-* Dependabot alerts activos para actualizar dependencias de Node y Python.
+
+- Docker: un proceso por contenedor; `docker-compose -f docker-compose.dev.yml up`.
+- CI = GitHub Actions: lint → tests → build Docker → push a ECR (staging).
+- Secrets via GitHub Secrets (nunca en el repo).
+- RPO ≤ 15 min, RTO ≤ 30 min (ver runbooks en `/docs/dr`).
+- Gestor Node = PNPM; habilita `corepack` para versiones homogéneas.
+- Dependabot alerts activos para actualizar dependencias de Node y Python.
 
 ### 6. Estilo de código
-* **Python**: `ruff` + `black --line-length 88` + `isort`.
-* **TypeScript**: `eslint` base Airbnb + `prettier`.
-* Naming: snake_case en Python, camelCase en TS; nada de abreviaturas crípticas.
-* Comentarios: escribe **por qué**, no **qué**.
+
+- **Python**: `ruff` + `black --line-length 88` + `isort`.
+- **TypeScript**: `eslint` base Airbnb + `prettier`.
+- Naming: snake_case en Python, camelCase en TS; nada de abreviaturas crípticas.
+- Comentarios: escribe **por qué**, no **qué**.
 
 ### 7. IA Codex (este agente)
-* Respeta siempre esta guía y el backlog “Single Source of Truth”.
-* Antes de generar código, **razona**: ¿impacta seguridad? ¿escala?
-* Al crear componentes React: genera archivo `.stories.tsx` y prueba básica.
-* Al crear endpoint FastAPI: genera test con `TestClient`.
+
+- Respeta siempre esta guía y el backlog “Single Source of Truth”.
+- Antes de generar código, **razona**: ¿impacta seguridad? ¿escala?
+- Al crear componentes React: genera archivo `.stories.tsx` y prueba básica.
+- Al crear endpoint FastAPI: genera test con `TestClient`.
 
 ---
 

--- a/frontend/src/components/molecules/LabeledSelectField.docs.mdx
+++ b/frontend/src/components/molecules/LabeledSelectField.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './LabeledSelectField.stories';
+import { LabeledSelectField } from './LabeledSelectField';
+
+<Meta of={Stories} />
+
+# LabeledSelectField
+
+Campo de selección desplegable con una etiqueta visible.
+
+<Story id="molecules-labeledselectfield--default" />
+
+<ArgsTable of={LabeledSelectField} story="Default" />

--- a/frontend/src/components/molecules/LabeledSelectField.stories.tsx
+++ b/frontend/src/components/molecules/LabeledSelectField.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { LabeledSelectField } from './LabeledSelectField';
+
+const meta: Meta<typeof LabeledSelectField> = {
+  title: 'Molecules/LabeledSelectField',
+  component: LabeledSelectField,
+  args: {
+    label: 'Estado',
+    options: [
+      { value: 'pendiente', label: 'Pendiente' },
+      { value: 'enviado', label: 'Enviado' },
+      { value: 'entregado', label: 'Entregado' },
+    ],
+    value: 'pendiente',
+  },
+  argTypes: {
+    onChange: { action: 'changed' },
+    value: { control: 'text' },
+    helperText: { control: 'text' },
+    error: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+    size: { control: 'radio', options: ['small', 'medium'] },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof LabeledSelectField>;
+
+export const Default: Story = {};
+
+export const WithValue: Story = {
+  args: { value: 'enviado' },
+};
+
+export const Disabled: Story = {
+  args: { disabled: true },
+};
+
+export const Error: Story = {
+  args: { error: true, helperText: 'Campo requerido' },
+};
+
+export const ManyOptions: Story = {
+  args: {
+    options: Array.from({ length: 20 }, (_, i) => ({
+      value: `opt${i}`,
+      label: `Opción ${i}`,
+    })),
+  },
+};

--- a/frontend/src/components/molecules/LabeledSelectField.test.tsx
+++ b/frontend/src/components/molecules/LabeledSelectField.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from '../../theme';
+import { LabeledSelectField } from './LabeledSelectField';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('LabeledSelectField', () => {
+  const options = [
+    { value: 'a', label: 'Opción A' },
+    { value: 'b', label: 'Opción B' },
+  ];
+
+  it('renders label and selected option', () => {
+    renderWithTheme(
+      <LabeledSelectField
+        label="Estado"
+        options={options}
+        value="a"
+        onChange={() => {}}
+      />,
+    );
+    const select = screen.getByLabelText('Estado');
+    expect(select).toHaveTextContent('Opción A');
+  });
+
+  it('calls onChange when selecting another option', async () => {
+    const user = userEvent.setup();
+    const handleChange = jest.fn();
+    renderWithTheme(
+      <LabeledSelectField
+        label="Estado"
+        options={options}
+        value="a"
+        onChange={handleChange}
+      />,
+    );
+    const button = screen.getByLabelText('Estado');
+    fireEvent.mouseDown(button);
+    await user.click(screen.getByRole('option', { name: 'Opción B' }));
+    expect(handleChange).toHaveBeenCalled();
+    const event = handleChange.mock.calls[0][0];
+    expect(event.target.value).toBe('b');
+  });
+
+  it('renders disabled state', async () => {
+    const handleChange = jest.fn();
+    renderWithTheme(
+      <LabeledSelectField
+        label="Estado"
+        options={options}
+        value="a"
+        disabled
+        onChange={handleChange}
+      />,
+    );
+    const button = screen.getByLabelText('Estado');
+    expect(button).toHaveAttribute('aria-disabled', 'true');
+    fireEvent.mouseDown(button);
+    expect(screen.queryByRole('option')).not.toBeInTheDocument();
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+
+  it('shows helper text in error state', () => {
+    renderWithTheme(
+      <LabeledSelectField
+        label="Estado"
+        options={options}
+        value="a"
+        error
+        helperText="Requerido"
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.getByText('Requerido')).toBeInTheDocument();
+    const select = screen.getByLabelText('Estado');
+    expect(select).toHaveAttribute('aria-invalid', 'true');
+  });
+});

--- a/frontend/src/components/molecules/LabeledSelectField.tsx
+++ b/frontend/src/components/molecules/LabeledSelectField.tsx
@@ -1,0 +1,74 @@
+import { Box, Typography } from '@mui/material';
+import { useId, useState } from 'react';
+import { Select, SelectProps } from '../atoms';
+
+export interface LabeledSelectFieldProps extends Omit<SelectProps, 'label'> {
+  /** Texto de la etiqueta */
+  label: string;
+}
+
+/**
+ * Campo de selección con etiqueta visible.
+ * Combina un `Select` y un `label` externo para formar
+ * un elemento de formulario coherente.
+ */
+export function LabeledSelectField({
+  label,
+  id,
+  options,
+  value,
+  onChange,
+  size = 'medium',
+  error = false,
+  helperText,
+  disabled = false,
+  onOpen,
+  onClose,
+  ...props
+}: LabeledSelectFieldProps) {
+  const generatedId = useId();
+  const selectId = id ?? generatedId;
+  const labelId = useId();
+  const [open, setOpen] = useState(false);
+
+  const handleOpen: NonNullable<SelectProps['onOpen']> = (e) => {
+    setOpen(true);
+    onOpen?.(e);
+  };
+
+  const handleClose: NonNullable<SelectProps['onClose']> = (e) => {
+    setOpen(false);
+    onClose?.(e);
+  };
+
+  return (
+    <Box display="flex" flexDirection="column" gap={0.5}>
+      <Typography
+        id={labelId}
+        component="label"
+        sx={{
+          mb: 0.5,
+          color: error ? 'error.main' : open ? 'primary.main' : undefined,
+        }}
+      >
+        {label}
+      </Typography>
+      <Select
+        id={selectId}
+        labelId={labelId}
+        options={options}
+        value={value}
+        onChange={onChange}
+        size={size}
+        error={error}
+        helperText={helperText}
+        disabled={disabled}
+        onOpen={handleOpen}
+        onClose={handleClose}
+        {...props}
+      />
+    </Box>
+  );
+}
+
+export default LabeledSelectField;

--- a/frontend/src/components/molecules/index.ts
+++ b/frontend/src/components/molecules/index.ts
@@ -1,1 +1,2 @@
 export { LabeledTextField } from './LabeledTextField';
+export { LabeledSelectField } from './LabeledSelectField';


### PR DESCRIPTION
## Summary
- extend AGENTS guidelines with module hierarchy
- add `LabeledSelectField` molecule with tests, stories and docs

## Testing
- `pnpm -r test`

------
https://chatgpt.com/codex/tasks/task_e_684dcb8039c0832bb880c7b85740a311