### PR TITLE
Add LabeledNumberField molecule

### DIFF
--- a/frontend/src/components/atoms/NumberInput.docs.mdx
+++ b/frontend/src/components/atoms/NumberInput.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './NumberInput.stories';
+import { NumberInput } from './NumberInput';
+
+<Meta of={Stories} />
+
+# NumberInput
+
+Campo de entrada numérico que rechaza caracteres no válidos.
+
+<Story id="atoms-numberinput--default" />
+
+<ArgsTable of={NumberInput} story="Default" />

--- a/frontend/src/components/atoms/NumberInput.stories.tsx
+++ b/frontend/src/components/atoms/NumberInput.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { NumberInput } from './NumberInput';
+
+const meta: Meta<typeof NumberInput> = {
+  title: 'Atoms/NumberInput',
+  component: NumberInput,
+  args: {
+    value: 0,
+  },
+  argTypes: {
+    onChange: { action: 'changed' },
+    value: { control: 'number' },
+    disabled: { control: 'boolean' },
+    helperText: { control: 'text' },
+    error: { control: 'boolean' },
+    min: { control: 'number' },
+    max: { control: 'number' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof NumberInput>;
+
+export const Default: Story = {};
+
+export const WithLimits: Story = {
+  args: { min: 0, max: 10 },
+};
+
+export const Disabled: Story = {
+  args: { disabled: true },
+};
+
+export const Error: Story = {
+  args: { error: true, helperText: 'Valor inválido' },
+};

--- a/frontend/src/components/atoms/NumberInput.test.tsx
+++ b/frontend/src/components/atoms/NumberInput.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { NumberInput } from './NumberInput';
+import { ThemeProvider } from '../../theme';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('NumberInput', () => {
+  it('renders with value and calls onChange for numbers', async () => {
+    const user = userEvent.setup();
+    const handleChange = jest.fn();
+    renderWithTheme(<NumberInput value={1} onChange={handleChange} />);
+    const input = screen.getByRole('spinbutton') as HTMLInputElement;
+    expect(input.value).toBe('1');
+    await user.type(input, '2');
+    expect(handleChange).toHaveBeenCalled();
+  });
+
+  it('ignores non numeric characters', async () => {
+    const user = userEvent.setup();
+    const handleChange = jest.fn();
+    renderWithTheme(<NumberInput value={0} onChange={handleChange} />);
+    const input = screen.getByRole('spinbutton');
+    await user.type(input, 'a');
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+
+  it('renders disabled state', async () => {
+    const handleChange = jest.fn();
+    renderWithTheme(<NumberInput value={0} disabled onChange={handleChange} />);
+    const input = screen.getByRole('spinbutton');
+    expect(input).toBeDisabled();
+    await userEvent.type(input, '1');
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/atoms/NumberInput.tsx
+++ b/frontend/src/components/atoms/NumberInput.tsx
@@ -1,0 +1,40 @@
+import { ChangeEvent } from 'react';
+import { TextField, TextFieldProps } from './TextField';
+
+export interface NumberInputProps
+  extends Omit<TextFieldProps, 'type' | 'value' | 'onChange'> {
+  /** Valor num\u00E9rico actual */
+  value: number | '';
+  /** Manejador de cambio con el nuevo valor num\u00E9rico o vac\u00EDo */
+  onChange: (event: ChangeEvent<HTMLInputElement>, value: number | '') => void;
+}
+
+/**
+ * Campo de entrada especializado para n\u00FAmeros.
+ * Rechaza caracteres no num\u00E9ricos.
+ */
+export function NumberInput({
+  value,
+  onChange,
+  inputProps,
+  ...props
+}: NumberInputProps) {
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const val = e.target.value;
+    if (val === '' || /^-?\d*(\.\d*)?$/.test(val)) {
+      onChange(e, val === '' ? '' : Number(val));
+    }
+  };
+
+  return (
+    <TextField
+      {...props}
+      type="number"
+      value={value}
+      onChange={handleChange}
+      inputProps={{ ...inputProps }}
+    />
+  );
+}
+
+export default NumberInput;

--- a/frontend/src/components/atoms/index.ts
+++ b/frontend/src/components/atoms/index.ts
@@ -18,3 +18,4 @@ export { Snackbar } from './Snackbar';
 export { Switch } from './Switch';
 export { Checkbox } from './Checkbox';
 export { RadioButton } from './RadioButton';
+export { NumberInput } from './NumberInput';

--- a/frontend/src/components/molecules/LabeledNumberField.docs.mdx
+++ b/frontend/src/components/molecules/LabeledNumberField.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './LabeledNumberField.stories';
+import { LabeledNumberField } from './LabeledNumberField';
+
+<Meta of={Stories} />
+
+# LabeledNumberField
+
+Campo numérico con una etiqueta visible asociada al input.
+
+<Story id="molecules-labelednumberfield--default" />
+
+<ArgsTable of={LabeledNumberField} story="Default" />

--- a/frontend/src/components/molecules/LabeledNumberField.stories.tsx
+++ b/frontend/src/components/molecules/LabeledNumberField.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { LabeledNumberField } from './LabeledNumberField';
+
+const meta: Meta<typeof LabeledNumberField> = {
+  title: 'Molecules/LabeledNumberField',
+  component: LabeledNumberField,
+  args: {
+    label: 'Cantidad',
+    value: 0,
+  },
+  argTypes: {
+    onChange: { action: 'changed' },
+    value: { control: 'number' },
+    helperText: { control: 'text' },
+    error: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+    min: { control: 'number' },
+    max: { control: 'number' },
+    autoFocus: { control: 'boolean' },
+    size: { control: 'radio', options: ['small', 'medium'] },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof LabeledNumberField>;
+
+export const Default: Story = {};
+
+export const WithLimits: Story = {
+  args: { min: 0, max: 10, value: 5 },
+};
+
+export const Disabled: Story = {
+  args: { disabled: true },
+};
+
+export const Error: Story = {
+  args: { error: true, helperText: 'Fuera de rango' },
+};

--- a/frontend/src/components/molecules/LabeledNumberField.test.tsx
+++ b/frontend/src/components/molecules/LabeledNumberField.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from '../../theme';
+import { LabeledNumberField } from './LabeledNumberField';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('LabeledNumberField', () => {
+  it('associates label and input', () => {
+    renderWithTheme(
+      <LabeledNumberField label="Cantidad" value={0} onChange={() => {}} />,
+    );
+    const input = screen.getByLabelText('Cantidad');
+    expect(input).toBeInTheDocument();
+  });
+
+  it('updates value on change with numbers only', async () => {
+    const user = userEvent.setup();
+    const handleChange = jest.fn();
+    renderWithTheme(
+      <LabeledNumberField label="Cantidad" value={0} onChange={handleChange} />,
+    );
+    const input = screen.getByLabelText('Cantidad') as HTMLInputElement;
+    await user.type(input, '5');
+    expect(handleChange).toHaveBeenCalled();
+  });
+
+  it('ignores non numeric characters', async () => {
+    const user = userEvent.setup();
+    const handleChange = jest.fn();
+    renderWithTheme(
+      <LabeledNumberField label="Cantidad" value={0} onChange={handleChange} />,
+    );
+    const input = screen.getByLabelText('Cantidad');
+    await user.type(input, 'a');
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+
+  it('renders disabled state', async () => {
+    const handleChange = jest.fn();
+    renderWithTheme(
+      <LabeledNumberField
+        label="Cantidad"
+        value={0}
+        disabled
+        onChange={handleChange}
+      />,
+    );
+    const input = screen.getByLabelText('Cantidad');
+    expect(input).toBeDisabled();
+    await userEvent.type(input, '1');
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+
+  it('shows error when value is out of range', () => {
+    renderWithTheme(
+      <LabeledNumberField
+        label="Cantidad"
+        value={10}
+        min={0}
+        max={5}
+        onChange={() => {}}
+      />,
+    );
+    const input = screen.getByLabelText('Cantidad');
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+  });
+});

--- a/frontend/src/components/molecules/LabeledNumberField.tsx
+++ b/frontend/src/components/molecules/LabeledNumberField.tsx
@@ -1,0 +1,76 @@
+import { Box, Typography } from '@mui/material';
+import { useId, useState } from 'react';
+import { NumberInput, NumberInputProps } from '../atoms';
+
+export interface LabeledNumberFieldProps extends Omit<NumberInputProps, 'label'> {
+  /** Texto de la etiqueta */
+  label: string;
+}
+
+/**
+ * Campo num\u00E9rico con etiqueta visible. Combina un `NumberInput`
+ * y un `label` asociado para formar una unidad de formulario.
+ */
+export function LabeledNumberField({
+  label,
+  id,
+  value,
+  onChange,
+  min,
+  max,
+  error = false,
+  helperText,
+  disabled = false,
+  onFocus,
+  onBlur,
+  ...props
+}: LabeledNumberFieldProps) {
+  const generatedId = useId();
+  const inputId = id ?? generatedId;
+  const [focused, setFocused] = useState(false);
+
+  const handleFocus: React.FocusEventHandler<HTMLInputElement> = (e) => {
+    setFocused(true);
+    onFocus?.(e);
+  };
+
+  const handleBlur: React.FocusEventHandler<HTMLInputElement> = (e) => {
+    setFocused(false);
+    onBlur?.(e);
+  };
+
+  const outOfRange =
+    typeof value === 'number' &&
+    ((min !== undefined && value < min) || (max !== undefined && value > max));
+
+  return (
+    <Box display="flex" flexDirection="column" gap={0.5}>
+      <Typography
+        component="label"
+        htmlFor={inputId}
+        sx={{
+          mb: 0.5,
+          color:
+            error || outOfRange ? 'error.main' : focused ? 'primary.main' : undefined,
+        }}
+      >
+        {label}
+      </Typography>
+      <NumberInput
+        id={inputId}
+        value={value}
+        onChange={onChange}
+        min={min}
+        max={max}
+        error={error || outOfRange}
+        helperText={helperText}
+        disabled={disabled}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
+        {...props}
+      />
+    </Box>
+  );
+}
+
+export default LabeledNumberField;

--- a/frontend/src/components/molecules/index.ts
+++ b/frontend/src/components/molecules/index.ts
@@ -1,2 +1,3 @@
 export { LabeledTextField } from './LabeledTextField';
 export { LabeledSelectField } from './LabeledSelectField';
+export { LabeledNumberField } from './LabeledNumberField';


### PR DESCRIPTION
## Summary
- add `NumberInput` atom
- add `LabeledNumberField` molecule
- document and test new components

## Testing
- `pnpm --filter ./frontend test`

------
https://chatgpt.com/codex/tasks/task_e_684dee96d424832b98a19a7229a07dcd