### PR TITLE
Add LabeledCurrencyField component

### DIFF
--- a/frontend/src/components/atoms/CurrencyField.docs.mdx
+++ b/frontend/src/components/atoms/CurrencyField.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './CurrencyField.stories';
+import { CurrencyField } from './CurrencyField';
+
+<Meta of={Stories} />
+
+# CurrencyField
+
+Campo de entrada para valores monetarios con formateo seg\u00FAn la moneda.
+
+<Story id="atoms-currencyfield--default" />
+
+<ArgsTable of={CurrencyField} story="Default" />

--- a/frontend/src/components/atoms/CurrencyField.stories.tsx
+++ b/frontend/src/components/atoms/CurrencyField.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { CurrencyField } from './CurrencyField';
+
+const meta: Meta<typeof CurrencyField> = {
+  title: 'Atoms/CurrencyField',
+  component: CurrencyField,
+  args: {
+    value: 0,
+    currency: 'USD',
+  },
+  argTypes: {
+    onChange: { action: 'changed' },
+    value: { control: 'number' },
+    currency: { control: 'text' },
+    disabled: { control: 'boolean' },
+    helperText: { control: 'text' },
+    error: { control: 'boolean' },
+    autoFocus: { control: 'boolean' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof CurrencyField>;
+
+export const Default: Story = {};
+
+export const WithEuro: Story = {
+  args: { currency: 'EUR', value: 10.5 },
+};
+
+export const Disabled: Story = {
+  args: { disabled: true },
+};
+
+export const Error: Story = {
+  args: { error: true, helperText: 'Valor inv\u00E1lido' },
+};

--- a/frontend/src/components/atoms/CurrencyField.test.tsx
+++ b/frontend/src/components/atoms/CurrencyField.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { CurrencyField } from './CurrencyField';
+import { ThemeProvider } from '../../theme';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('CurrencyField', () => {
+  it('formats value on blur', async () => {
+    const user = userEvent.setup();
+    renderWithTheme(<CurrencyField value={1000} onChange={() => {}} currency="USD" />);
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    await user.click(input);
+    await user.tab();
+    expect(input.value).toBe(
+      new Intl.NumberFormat('en-US', {
+        style: 'currency',
+        currency: 'USD',
+      }).format(1000),
+    );
+  });
+
+  it('ignores non numeric characters', async () => {
+    const user = userEvent.setup();
+    const handleChange = jest.fn();
+    renderWithTheme(<CurrencyField value={0} onChange={handleChange} />);
+    const input = screen.getByRole('textbox');
+    await user.type(input, 'a');
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+
+  it('renders disabled state', async () => {
+    const handleChange = jest.fn();
+    renderWithTheme(<CurrencyField value={0} disabled onChange={handleChange} />);
+    const input = screen.getByRole('textbox');
+    expect(input).toBeDisabled();
+    await userEvent.type(input, '1');
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/atoms/CurrencyField.tsx
+++ b/frontend/src/components/atoms/CurrencyField.tsx
@@ -1,0 +1,65 @@
+import { ChangeEvent, useState } from 'react';
+import { TextField, TextFieldProps } from './TextField';
+
+export interface CurrencyFieldProps
+  extends Omit<TextFieldProps, 'type' | 'value' | 'onChange'> {
+  /** Valor num\u00E9rico actual */
+  value: number | '';
+  /** C\u00F3digo de moneda ISO 4217 */
+  currency?: string;
+  /** Manejador de cambio con el nuevo valor num\u00E9rico o vac\u00EDo */
+  onChange: (event: ChangeEvent<HTMLInputElement>, value: number | '') => void;
+}
+
+/**
+ * Campo de entrada especializado para valores monetarios.
+ * Formatea seg\u00FAn la moneda al perder el foco.
+ */
+export function CurrencyField({
+  value,
+  onChange,
+  currency = 'USD',
+  onFocus,
+  onBlur,
+  inputProps,
+  ...props
+}: CurrencyFieldProps) {
+  const [focused, setFocused] = useState(false);
+
+  const format = (val: number) =>
+    new Intl.NumberFormat('en-US', { style: 'currency', currency }).format(val);
+
+  const displayValue = value === '' ? '' : focused ? String(value) : format(value);
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const val = e.target.value;
+    const sanitized = val.replace(/[^0-9.-]/g, '');
+    if (val === sanitized && (sanitized === '' || /^-?\d*(\.\d*)?$/.test(sanitized))) {
+      onChange(e, sanitized === '' ? '' : Number(sanitized));
+    }
+  };
+
+  const handleFocus: React.FocusEventHandler<HTMLInputElement> = (e) => {
+    setFocused(true);
+    onFocus?.(e);
+  };
+
+  const handleBlur: React.FocusEventHandler<HTMLInputElement> = (e) => {
+    setFocused(false);
+    onBlur?.(e);
+  };
+
+  return (
+    <TextField
+      {...props}
+      type="text"
+      value={displayValue}
+      onChange={handleChange}
+      onFocus={handleFocus}
+      onBlur={handleBlur}
+      inputProps={{ ...inputProps }}
+    />
+  );
+}
+
+export default CurrencyField;

--- a/frontend/src/components/atoms/index.ts
+++ b/frontend/src/components/atoms/index.ts
@@ -20,3 +20,4 @@ export { Checkbox } from './Checkbox';
 export { RadioButton } from './RadioButton';
 export { NumberInput } from './NumberInput';
 export { DatePicker } from './DatePicker';
+export { CurrencyField } from './CurrencyField';

--- a/frontend/src/components/molecules/LabeledCurrencyField.docs.mdx
+++ b/frontend/src/components/molecules/LabeledCurrencyField.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './LabeledCurrencyField.stories';
+import { LabeledCurrencyField } from './LabeledCurrencyField';
+
+<Meta of={Stories} />
+
+# LabeledCurrencyField
+
+Campo de moneda con una etiqueta visible asociada al input.
+
+<Story id="molecules-labeledcurrencyfield--default" />
+
+<ArgsTable of={LabeledCurrencyField} story="Default" />

--- a/frontend/src/components/molecules/LabeledCurrencyField.stories.tsx
+++ b/frontend/src/components/molecules/LabeledCurrencyField.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { LabeledCurrencyField } from './LabeledCurrencyField';
+
+const meta: Meta<typeof LabeledCurrencyField> = {
+  title: 'Molecules/LabeledCurrencyField',
+  component: LabeledCurrencyField,
+  args: {
+    label: 'Precio',
+    value: 0,
+    currency: 'USD',
+  },
+  argTypes: {
+    onChange: { action: 'changed' },
+    value: { control: 'number' },
+    currency: { control: 'text' },
+    helperText: { control: 'text' },
+    error: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+    min: { control: 'number' },
+    max: { control: 'number' },
+    autoFocus: { control: 'boolean' },
+    size: { control: 'radio', options: ['small', 'medium'] },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof LabeledCurrencyField>;
+
+export const Default: Story = {};
+
+export const WithValue: Story = {
+  args: { value: 123.45 },
+};
+
+export const Euro: Story = {
+  args: { currency: 'EUR', value: 40 },
+};
+
+export const Disabled: Story = {
+  args: { disabled: true },
+};
+
+export const Error: Story = {
+  args: { error: true, helperText: 'Fuera de rango' },
+};

--- a/frontend/src/components/molecules/LabeledCurrencyField.test.tsx
+++ b/frontend/src/components/molecules/LabeledCurrencyField.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from '../../theme';
+import { LabeledCurrencyField } from './LabeledCurrencyField';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('LabeledCurrencyField', () => {
+  it('associates label and input', () => {
+    renderWithTheme(
+      <LabeledCurrencyField label="Precio" value={0} onChange={() => {}} />,
+    );
+    const input = screen.getByLabelText('Precio');
+    expect(input).toBeInTheDocument();
+  });
+
+  it('formats value on blur', async () => {
+    const user = userEvent.setup();
+    renderWithTheme(
+      <LabeledCurrencyField label="Precio" value={1000} onChange={() => {}} />,
+    );
+    const input = screen.getByLabelText('Precio');
+    await user.click(input);
+    await user.tab();
+    expect((input as HTMLInputElement).value).toBe(
+      new Intl.NumberFormat('en-US', {
+        style: 'currency',
+        currency: 'USD',
+      }).format(1000),
+    );
+  });
+
+  it('ignores non numeric characters', async () => {
+    const user = userEvent.setup();
+    const handleChange = jest.fn();
+    renderWithTheme(
+      <LabeledCurrencyField label="Precio" value={0} onChange={handleChange} />,
+    );
+    const input = screen.getByLabelText('Precio');
+    await user.type(input, 'a');
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+
+  it('renders disabled state', async () => {
+    const handleChange = jest.fn();
+    renderWithTheme(
+      <LabeledCurrencyField
+        label="Precio"
+        value={0}
+        disabled
+        onChange={handleChange}
+      />,
+    );
+    const input = screen.getByLabelText('Precio');
+    expect(input).toBeDisabled();
+    await userEvent.type(input, '1');
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+
+  it('shows error when value is out of range', () => {
+    renderWithTheme(
+      <LabeledCurrencyField
+        label="Precio"
+        value={10}
+        min={0}
+        max={5}
+        onChange={() => {}}
+      />,
+    );
+    const input = screen.getByLabelText('Precio');
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+  });
+});

--- a/frontend/src/components/molecules/LabeledCurrencyField.tsx
+++ b/frontend/src/components/molecules/LabeledCurrencyField.tsx
@@ -1,0 +1,78 @@
+import { Box, Typography } from '@mui/material';
+import { useId, useState } from 'react';
+import { CurrencyField, CurrencyFieldProps } from '../atoms';
+
+export interface LabeledCurrencyFieldProps extends Omit<CurrencyFieldProps, 'label'> {
+  /** Texto de la etiqueta */
+  label: string;
+}
+
+/**
+ * Campo de moneda con etiqueta visible.
+ * Combina un `CurrencyField` y un `label` para un formulario accesible.
+ */
+export function LabeledCurrencyField({
+  label,
+  id,
+  value,
+  onChange,
+  currency = 'USD',
+  min,
+  max,
+  error = false,
+  helperText,
+  disabled = false,
+  onFocus,
+  onBlur,
+  ...props
+}: LabeledCurrencyFieldProps) {
+  const generatedId = useId();
+  const inputId = id ?? generatedId;
+  const [focused, setFocused] = useState(false);
+
+  const handleFocus: React.FocusEventHandler<HTMLInputElement> = (e) => {
+    setFocused(true);
+    onFocus?.(e);
+  };
+
+  const handleBlur: React.FocusEventHandler<HTMLInputElement> = (e) => {
+    setFocused(false);
+    onBlur?.(e);
+  };
+
+  const outOfRange =
+    typeof value === 'number' &&
+    ((min !== undefined && value < min) || (max !== undefined && value > max));
+
+  return (
+    <Box display="flex" flexDirection="column" gap={0.5}>
+      <Typography
+        component="label"
+        htmlFor={inputId}
+        sx={{
+          mb: 0.5,
+          color:
+            error || outOfRange ? 'error.main' : focused ? 'primary.main' : undefined,
+        }}
+      >
+        {label}
+      </Typography>
+      <CurrencyField
+        id={inputId}
+        value={value}
+        onChange={onChange}
+        currency={currency}
+        min={min}
+        max={max}
+        error={error || outOfRange}
+        helperText={helperText}
+        disabled={disabled}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
+        {...props}
+      />
+    </Box>
+  );
+}
+
+export default LabeledCurrencyField;

--- a/frontend/src/components/molecules/index.ts
+++ b/frontend/src/components/molecules/index.ts
@@ -2,3 +2,4 @@ export { LabeledTextField } from './LabeledTextField';
 export { LabeledSelectField } from './LabeledSelectField';
 export { LabeledNumberField } from './LabeledNumberField';
 export { LabeledDateField } from './LabeledDateField';
+export { LabeledCurrencyField } from './LabeledCurrencyField';


### PR DESCRIPTION
## Summary
- implement `CurrencyField` atom with currency formatting
- add `LabeledCurrencyField` molecule using the new atom
- document components with stories and MDX docs
- provide unit tests for new atom and molecule

## Testing
- `pnpm --filter erp-frontend lint`
- `pnpm --filter erp-frontend test`


------
https://chatgpt.com/codex/tasks/task_e_684eefb8292c832bbf0f09aa3f606df5