### PR TITLE
feat(frontend): add RadioButtonGroup molecule

### DIFF
--- a/frontend/src/components/molecules/RadioButtonGroup.docs.mdx
+++ b/frontend/src/components/molecules/RadioButtonGroup.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './RadioButtonGroup.stories';
+import { RadioButtonGroup } from './RadioButtonGroup';
+
+<Meta of={Stories} />
+
+# RadioButtonGroup
+
+Grupo de botones de opción para seleccionar un único valor.
+
+<Story id="molecules-radiobuttongroup--vertical" />
+
+<ArgsTable of={RadioButtonGroup} story="Vertical" />

--- a/frontend/src/components/molecules/RadioButtonGroup.stories.tsx
+++ b/frontend/src/components/molecules/RadioButtonGroup.stories.tsx
@@ -1,0 +1,60 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { RadioButtonGroup } from './RadioButtonGroup';
+
+const meta: Meta<typeof RadioButtonGroup> = {
+  title: 'Molecules/RadioButtonGroup',
+  component: RadioButtonGroup,
+  args: {
+    label: 'Género',
+    options: [
+      { value: 'hombre', label: 'Hombre' },
+      { value: 'mujer', label: 'Mujer' },
+      { value: 'n/a', label: 'No definido' },
+    ],
+    value: 'hombre',
+  },
+  argTypes: {
+    onChange: { action: 'changed' },
+    value: { control: 'text' },
+    orientation: { control: 'radio', options: ['vertical', 'horizontal'] },
+    disabled: { control: 'boolean' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof RadioButtonGroup>;
+
+export const Vertical: Story = {};
+
+export const Horizontal: Story = {
+  args: { orientation: 'horizontal' },
+};
+
+export const OptionDisabled: Story = {
+  args: {
+    options: [
+      { value: 'hombre', label: 'Hombre' },
+      { value: 'mujer', label: 'Mujer', disabled: true },
+      { value: 'n/a', label: 'No definido' },
+    ],
+    value: 'n/a',
+  },
+};
+
+export const GroupDisabled: Story = {
+  args: { disabled: true },
+};
+
+export const LongLabel: Story = {
+  args: {
+    options: [
+      {
+        value: 'l',
+        label:
+          'Opción con una etiqueta extremadamente larga para probar el comportamiento',
+      },
+      { value: 's', label: 'Corta' },
+    ],
+    value: 'l',
+  },
+};

--- a/frontend/src/components/molecules/RadioButtonGroup.test.tsx
+++ b/frontend/src/components/molecules/RadioButtonGroup.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from '../../theme';
+import { RadioButtonGroup, RadioButtonOption } from './RadioButtonGroup';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+const options: RadioButtonOption[] = [
+  { value: 'a', label: 'A' },
+  { value: 'b', label: 'B' },
+  { value: 'c', label: 'C' },
+];
+
+describe('RadioButtonGroup', () => {
+  it('renders all options and only one can be selected', () => {
+    renderWithTheme(
+      <RadioButtonGroup value="a" options={options} onChange={() => {}} />,
+    );
+    const radios = screen.getAllByRole('radio') as HTMLInputElement[];
+    expect(radios).toHaveLength(3);
+    expect(radios[0].checked).toBe(true);
+    expect(radios[1].checked).toBe(false);
+  });
+
+  it('selects option on click and calls onChange', async () => {
+    const user = userEvent.setup();
+    const handleChange = jest.fn();
+    renderWithTheme(
+      <RadioButtonGroup value="a" options={options} onChange={handleChange} />,
+    );
+    const radios = screen.getAllByRole('radio');
+    await user.click(radios[1]);
+    expect(handleChange).toHaveBeenCalled();
+  });
+
+  it('navigates with keyboard', async () => {
+    const user = userEvent.setup();
+    const handleChange = jest.fn();
+    renderWithTheme(
+      <RadioButtonGroup value="a" options={options} onChange={handleChange} />,
+    );
+    await user.tab(); // focus first radio
+    await user.keyboard('[ArrowDown]');
+    await user.keyboard('[Space]');
+    expect(handleChange).toHaveBeenCalled();
+  });
+
+  it('is disabled when group disabled', async () => {
+    const user = userEvent.setup();
+    const handleChange = jest.fn();
+    renderWithTheme(
+      <RadioButtonGroup value="a" options={options} onChange={handleChange} disabled />,
+    );
+    const radios = screen.getAllByRole('radio');
+    expect(radios[0]).toBeDisabled();
+    await expect(user.click(radios[1])).rejects.toThrow();
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/molecules/RadioButtonGroup.tsx
+++ b/frontend/src/components/molecules/RadioButtonGroup.tsx
@@ -1,0 +1,70 @@
+import { FormControl, FormLabel, RadioGroup, FormControlLabel } from '@mui/material';
+import { useId } from 'react';
+import { RadioButton } from '../atoms';
+
+export interface RadioButtonOption {
+  /** Texto visible de la opción */
+  label: string;
+  /** Valor asociado a la opción */
+  value: string | number;
+  /** Deshabilita esta opción individual */
+  disabled?: boolean;
+}
+
+export interface RadioButtonGroupProps {
+  /** Título del grupo de opciones */
+  label?: string;
+  /** Opciones disponibles para seleccionar */
+  options: RadioButtonOption[];
+  /** Valor seleccionado actualmente */
+  value: string | number;
+  /** Manejador de cambio */
+  onChange: (
+    event: React.ChangeEvent<HTMLInputElement>,
+    value: string | number,
+  ) => void;
+  /** Orientación del grupo */
+  orientation?: 'vertical' | 'horizontal';
+  /** Deshabilita todo el grupo */
+  disabled?: boolean;
+  /** Nombre del grupo; si se omite se genera uno */
+  name?: string;
+}
+
+/**
+ * Conjunto exclusivo de `RadioButton` con una etiqueta opcional.
+ */
+export function RadioButtonGroup({
+  label,
+  options,
+  value,
+  onChange,
+  orientation = 'vertical',
+  disabled = false,
+  name,
+}: RadioButtonGroupProps) {
+  const generatedName = useId();
+  return (
+    <FormControl component="fieldset" disabled={disabled}>
+      {label && <FormLabel>{label}</FormLabel>}
+      <RadioGroup
+        name={name ?? generatedName}
+        value={value}
+        onChange={onChange}
+        row={orientation === 'horizontal'}
+      >
+        {options.map((opt) => (
+          <FormControlLabel
+            key={opt.value}
+            value={opt.value}
+            control={<RadioButton />}
+            label={opt.label}
+            disabled={opt.disabled}
+          />
+        ))}
+      </RadioGroup>
+    </FormControl>
+  );
+}
+
+export default RadioButtonGroup;

--- a/frontend/src/components/molecules/index.ts
+++ b/frontend/src/components/molecules/index.ts
@@ -3,3 +3,4 @@ export { LabeledSelectField } from './LabeledSelectField';
 export { LabeledNumberField } from './LabeledNumberField';
 export { LabeledDateField } from './LabeledDateField';
 export { LabeledCurrencyField } from './LabeledCurrencyField';
+export { RadioButtonGroup } from './RadioButtonGroup';


### PR DESCRIPTION
## Summary
- add RadioButtonGroup component
- document component via MDX and storybook
- test RadioButtonGroup interactions

## Testing
- `pnpm run lint`
- `pnpm run test`

------
https://chatgpt.com/codex/tasks/task_e_684eff5264b8832bbdbe584527decdf6