### PR TITLE
feat(frontend): add ToggleSwitchField molecule

### DIFF
--- a/frontend/src/components/molecules/ToggleSwitchField.docs.mdx
+++ b/frontend/src/components/molecules/ToggleSwitchField.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './ToggleSwitchField.stories';
+import { ToggleSwitchField } from './ToggleSwitchField';
+
+<Meta of={Stories} />
+
+# ToggleSwitchField
+
+Interruptor con etiqueta para opciones de activación o desactivación.
+
+<Story id="molecules-toggleswitchfield--default" />
+
+<ArgsTable of={ToggleSwitchField} story="Default" />

--- a/frontend/src/components/molecules/ToggleSwitchField.stories.tsx
+++ b/frontend/src/components/molecules/ToggleSwitchField.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ToggleSwitchField } from './ToggleSwitchField';
+
+const meta: Meta<typeof ToggleSwitchField> = {
+  title: 'Molecules/ToggleSwitchField',
+  component: ToggleSwitchField,
+  args: {
+    label: 'Activo',
+    checked: false,
+  },
+  argTypes: {
+    onChange: { action: 'changed' },
+    checked: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+    labelPlacement: { control: 'radio', options: ['start', 'end'] },
+    size: { control: 'select', options: ['medium', 'small'] },
+    color: {
+      control: 'select',
+      options: ['primary', 'secondary', 'error', 'info', 'default'],
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof ToggleSwitchField>;
+
+export const Default: Story = {};
+
+export const Checked: Story = {
+  args: { checked: true },
+};
+
+export const Disabled: Story = {
+  args: { disabled: true },
+};
+
+export const LabelStart: Story = {
+  args: { labelPlacement: 'start' },
+};

--- a/frontend/src/components/molecules/ToggleSwitchField.test.tsx
+++ b/frontend/src/components/molecules/ToggleSwitchField.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from '../../theme';
+import { ToggleSwitchField } from './ToggleSwitchField';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('ToggleSwitchField', () => {
+  it('associates label and switch', () => {
+    renderWithTheme(
+      <ToggleSwitchField label="Activo" checked={false} onChange={() => {}} />,
+    );
+    const input = screen.getByLabelText('Activo');
+    expect(input).toBeInTheDocument();
+  });
+
+  it('toggles on click and emits change', async () => {
+    const user = userEvent.setup();
+    const handleChange = jest.fn();
+    renderWithTheme(
+      <ToggleSwitchField label="Activo" checked={false} onChange={handleChange} />,
+    );
+    await user.click(screen.getByLabelText('Activo'));
+    expect(handleChange).toHaveBeenCalled();
+  });
+
+  it('toggles with keyboard', async () => {
+    const user = userEvent.setup();
+    const handleChange = jest.fn();
+    renderWithTheme(
+      <ToggleSwitchField label="Activo" checked={false} onChange={handleChange} />,
+    );
+    await user.tab();
+    await user.keyboard('[Space]');
+    expect(handleChange).toHaveBeenCalled();
+  });
+
+  it('does not change when disabled', async () => {
+    const user = userEvent.setup();
+    const handleChange = jest.fn();
+    renderWithTheme(
+      <ToggleSwitchField
+        label="Activo"
+        checked={false}
+        disabled
+        onChange={handleChange}
+      />,
+    );
+    const input = screen.getByLabelText('Activo');
+    expect(input).toBeDisabled();
+    await expect(user.click(input)).rejects.toThrow();
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/molecules/ToggleSwitchField.tsx
+++ b/frontend/src/components/molecules/ToggleSwitchField.tsx
@@ -1,0 +1,71 @@
+import { Box, Typography } from '@mui/material';
+import { useId, useState } from 'react';
+import { Switch, SwitchProps } from '../atoms';
+
+export interface ToggleSwitchFieldProps extends SwitchProps {
+  /** Texto de la etiqueta */
+  label: string;
+  /** Posición de la etiqueta respecto al switch */
+  labelPlacement?: 'start' | 'end';
+}
+
+/**
+ * Interruptor con etiqueta visible asociado al control.
+ */
+export function ToggleSwitchField({
+  label,
+  id,
+  checked = false,
+  onChange,
+  disabled = false,
+  onFocus,
+  onBlur,
+  labelPlacement = 'end',
+  ...props
+}: ToggleSwitchFieldProps) {
+  const generatedId = useId();
+  const switchId = id ?? generatedId;
+  const [focused, setFocused] = useState(false);
+
+  const handleFocus: React.FocusEventHandler<HTMLInputElement> = (e) => {
+    setFocused(true);
+    onFocus?.(e);
+  };
+
+  const handleBlur: React.FocusEventHandler<HTMLInputElement> = (e) => {
+    setFocused(false);
+    onBlur?.(e);
+  };
+
+  const labelNode = (
+    <Typography
+      component="label"
+      htmlFor={switchId}
+      sx={{
+        userSelect: 'none',
+        color: disabled ? 'text.disabled' : focused ? 'primary.main' : undefined,
+        mb: 0,
+      }}
+    >
+      {label}
+    </Typography>
+  );
+
+  return (
+    <Box display="flex" alignItems="center" gap={1}>
+      {labelPlacement === 'start' && labelNode}
+      <Switch
+        id={switchId}
+        checked={checked}
+        onChange={onChange}
+        disabled={disabled}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
+        {...props}
+      />
+      {labelPlacement === 'end' && labelNode}
+    </Box>
+  );
+}
+
+export default ToggleSwitchField;

--- a/frontend/src/components/molecules/index.ts
+++ b/frontend/src/components/molecules/index.ts
@@ -4,3 +4,4 @@ export { LabeledNumberField } from './LabeledNumberField';
 export { LabeledDateField } from './LabeledDateField';
 export { LabeledCurrencyField } from './LabeledCurrencyField';
 export { RadioButtonGroup } from './RadioButtonGroup';
+export { ToggleSwitchField } from './ToggleSwitchField';


### PR DESCRIPTION
## Summary
- add `ToggleSwitchField` molecule to combine a switch with a label
- expose the new molecule from `index.ts`
- cover the component with tests, docs and Storybook stories

## Testing
- `pnpm --dir frontend lint`
- `pnpm --dir frontend test`
- `pytest -q` *(fails: ModuleNotFoundError for fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_684f06936fe4832b87bab49c3edf2d10