### PR TITLE
feat(ui): add SearchBar molecule

### DIFF
--- a/frontend/src/components/molecules/SearchBar.docs.mdx
+++ b/frontend/src/components/molecules/SearchBar.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './SearchBar.stories';
+import { SearchBar } from './SearchBar';
+
+<Meta of={Stories} />
+
+# SearchBar
+
+Barra de búsqueda con campo de texto y botón icónico.
+
+<Story id="molecules-searchbar--default" />
+
+<ArgsTable of={SearchBar} story="Default" />

--- a/frontend/src/components/molecules/SearchBar.stories.tsx
+++ b/frontend/src/components/molecules/SearchBar.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { SearchBar } from './SearchBar';
+
+const meta: Meta<typeof SearchBar> = {
+  title: 'Molecules/SearchBar',
+  component: SearchBar,
+  args: {
+    placeholder: 'Buscar',
+  },
+  argTypes: {
+    onSearch: { action: 'searched' },
+    disabled: { control: 'boolean' },
+    placeholder: { control: 'text' },
+    size: { control: 'radio', options: ['small', 'medium'] },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof SearchBar>;
+
+export const Default: Story = {};
+
+export const Disabled: Story = {
+  args: { disabled: true },
+};
+
+export const Small: Story = {
+  args: { size: 'small' },
+};

--- a/frontend/src/components/molecules/SearchBar.test.tsx
+++ b/frontend/src/components/molecules/SearchBar.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from '../../theme';
+import { SearchBar } from './SearchBar';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('SearchBar', () => {
+  it('renders input and button', () => {
+    renderWithTheme(<SearchBar onSearch={() => {}} />);
+    expect(screen.getByLabelText('search input')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /search/i })).toBeInTheDocument();
+  });
+
+  it('updates query on typing', async () => {
+    const user = userEvent.setup();
+    renderWithTheme(<SearchBar onSearch={() => {}} />);
+    const input = screen.getByLabelText('search input') as HTMLInputElement;
+    await user.type(input, 'zapatos');
+    expect(input.value).toBe('zapatos');
+  });
+
+  it('calls onSearch when clicking button', async () => {
+    const user = userEvent.setup();
+    const handleSearch = jest.fn();
+    renderWithTheme(<SearchBar onSearch={handleSearch} />);
+    const input = screen.getByLabelText('search input');
+    await user.type(input, 'jeans');
+    await user.click(screen.getByRole('button', { name: /search/i }));
+    expect(handleSearch).toHaveBeenCalledWith('jeans');
+  });
+
+  it('calls onSearch when pressing Enter', async () => {
+    const user = userEvent.setup();
+    const handleSearch = jest.fn();
+    renderWithTheme(<SearchBar onSearch={handleSearch} />);
+    const input = screen.getByLabelText('search input');
+    await user.type(input, 'camisas');
+    await user.keyboard('[Enter]');
+    expect(handleSearch).toHaveBeenCalledWith('camisas');
+  });
+
+  it('is not interactive when disabled', async () => {
+    const user = userEvent.setup();
+    const handleSearch = jest.fn();
+    renderWithTheme(<SearchBar onSearch={handleSearch} disabled />);
+    const input = screen.getByLabelText('search input');
+    const button = screen.getByRole('button', { name: /search/i });
+    expect(input).toBeDisabled();
+    expect(button).toBeDisabled();
+    await user.type(input, 'test');
+    button.click();
+    expect(handleSearch).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/molecules/SearchBar.tsx
+++ b/frontend/src/components/molecules/SearchBar.tsx
@@ -1,0 +1,72 @@
+import SearchIcon from '@mui/icons-material/Search';
+import { Box } from '@mui/material';
+import { useState, KeyboardEvent } from 'react';
+import { TextField, IconButton } from '../atoms';
+
+export interface SearchBarProps {
+  /** Texto inicial de la consulta */
+  initialQuery?: string;
+  /** Callback ejecutado al realizar la búsqueda */
+  onSearch: (query: string) => void;
+  /** Deshabilita la barra de búsqueda */
+  disabled?: boolean;
+  /** Placeholder opcional para el campo */
+  placeholder?: string;
+  /** Tamaño del campo */
+  size?: 'small' | 'medium';
+}
+
+/**
+ * Barra de búsqueda compuesta por un `TextField` y un `IconButton`.
+ * Mantiene internamente el texto ingresado y dispara `onSearch`
+ * al hacer click en el botón o presionar Enter.
+ */
+export function SearchBar({
+  initialQuery = '',
+  onSearch,
+  disabled = false,
+  placeholder,
+  size = 'medium',
+}: SearchBarProps) {
+  const [query, setQuery] = useState(initialQuery);
+
+  const handleChange: React.ChangeEventHandler<HTMLInputElement> = (e) => {
+    setQuery(e.target.value);
+  };
+
+  const triggerSearch = () => {
+    if (!disabled) {
+      onSearch(query);
+    }
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      triggerSearch();
+    }
+  };
+
+  return (
+    <Box display="flex" alignItems="center" gap={1}>
+      <TextField
+        value={query}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+        disabled={disabled}
+        size={size}
+        inputProps={{ 'aria-label': 'search input' }}
+      />
+      <IconButton
+        icon={<SearchIcon />}
+        onClick={triggerSearch}
+        disabled={disabled}
+        aria-label="search"
+        sx={{ borderRadius: '50%' }}
+      />
+    </Box>
+  );
+}
+
+export default SearchBar;

--- a/frontend/src/components/molecules/index.ts
+++ b/frontend/src/components/molecules/index.ts
@@ -5,3 +5,4 @@ export { LabeledDateField } from './LabeledDateField';
 export { LabeledCurrencyField } from './LabeledCurrencyField';
 export { RadioButtonGroup } from './RadioButtonGroup';
 export { ToggleSwitchField } from './ToggleSwitchField';
+export { SearchBar } from './SearchBar';


### PR DESCRIPTION
## Summary
- create `SearchBar` molecule using TextField and IconButton
- add Storybook stories and MDX docs
- implement unit tests and export from index

## Testing
- `pnpm --filter erp-frontend lint`
- `pnpm --filter erp-frontend test`

------
https://chatgpt.com/codex/tasks/task_e_684f0cd45018832bae3449b50c1036d6