### PR TITLE
Add NumberStepper molecule

### DIFF
--- a/frontend/src/components/molecules/NumberStepper.docs.mdx
+++ b/frontend/src/components/molecules/NumberStepper.docs.mdx
@@ -1,0 +1,16 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './NumberStepper.stories';
+import { NumberStepper } from './NumberStepper';
+
+<Meta of={Stories} />
+
+# NumberStepper
+
+Control numérico con botones de incremento y decremento.
+
+Puede usarse como componente **controlado** (pasando `value` y `onChange`) o
+de forma **no controlada** mediante `defaultValue`.
+
+<Story id="molecules-numberstepper--default" />
+
+<ArgsTable of={NumberStepper} story="Default" />

--- a/frontend/src/components/molecules/NumberStepper.stories.tsx
+++ b/frontend/src/components/molecules/NumberStepper.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { NumberStepper } from './NumberStepper';
+
+const meta: Meta<typeof NumberStepper> = {
+  title: 'Molecules/NumberStepper',
+  component: NumberStepper,
+  args: {
+    defaultValue: 0,
+  },
+  argTypes: {
+    onChange: { action: 'changed' },
+    value: { control: 'number' },
+    defaultValue: { control: 'number' },
+    min: { control: 'number' },
+    max: { control: 'number' },
+    step: { control: 'number' },
+    disabled: { control: 'boolean' },
+    size: { control: 'radio', options: ['small', 'medium'] },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof NumberStepper>;
+
+export const Default: Story = {};
+
+export const WithLimits: Story = {
+  args: { min: 0, max: 5 },
+};
+
+export const Disabled: Story = {
+  args: { disabled: true },
+};
+
+export const StepTen: Story = {
+  args: { step: 10 },
+};

--- a/frontend/src/components/molecules/NumberStepper.test.tsx
+++ b/frontend/src/components/molecules/NumberStepper.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { ThemeProvider } from '../../theme';
+import { NumberStepper } from './NumberStepper';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('NumberStepper', () => {
+  it('shows the initial value', () => {
+    renderWithTheme(<NumberStepper defaultValue={3} />);
+    const input = screen.getByRole('spinbutton') as HTMLInputElement;
+    expect(input.value).toBe('3');
+  });
+
+  it('increments value on button click', async () => {
+    const user = userEvent.setup();
+    renderWithTheme(<NumberStepper defaultValue={0} />);
+    await user.click(screen.getByRole('button', { name: /increment/i }));
+    expect(screen.getByRole('spinbutton')).toHaveValue(1);
+  });
+
+  it('decrements value on button click', async () => {
+    const user = userEvent.setup();
+    renderWithTheme(<NumberStepper defaultValue={0} />);
+    await user.click(screen.getByRole('button', { name: /decrement/i }));
+    expect(screen.getByRole('spinbutton')).toHaveValue(-1);
+  });
+
+  it('does not decrement below min', async () => {
+    const user = userEvent.setup();
+    renderWithTheme(<NumberStepper defaultValue={0} min={0} />);
+    const dec = screen.getByRole('button', { name: /decrement/i });
+    await expect(user.click(dec)).rejects.toThrow();
+    expect(screen.getByRole('spinbutton')).toHaveValue(0);
+  });
+
+  it('does not increment above max', async () => {
+    const user = userEvent.setup();
+    renderWithTheme(<NumberStepper defaultValue={1} max={1} />);
+    const inc = screen.getByRole('button', { name: /increment/i });
+    await expect(user.click(inc)).rejects.toThrow();
+    expect(screen.getByRole('spinbutton')).toHaveValue(1);
+  });
+
+  it('normalizes manual input on blur', async () => {
+    const user = userEvent.setup();
+    renderWithTheme(<NumberStepper defaultValue={0} min={0} max={5} />);
+    const input = screen.getByRole('spinbutton');
+    await user.click(input);
+    await user.clear(input);
+    await user.type(input, '10');
+    fireEvent.blur(input);
+    expect(input).toHaveValue(5);
+  });
+
+  it('is disabled when prop disabled', async () => {
+    const user = userEvent.setup();
+    const handleChange = jest.fn();
+    renderWithTheme(<NumberStepper value={1} onChange={handleChange} disabled />);
+    const input = screen.getByRole('spinbutton');
+    const inc = screen.getByRole('button', { name: /increment/i });
+    const dec = screen.getByRole('button', { name: /decrement/i });
+    expect(input).toBeDisabled();
+    expect(inc).toBeDisabled();
+    expect(dec).toBeDisabled();
+    await expect(user.click(inc)).rejects.toThrow();
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/molecules/NumberStepper.tsx
+++ b/frontend/src/components/molecules/NumberStepper.tsx
@@ -1,0 +1,116 @@
+import AddIcon from '@mui/icons-material/Add';
+import RemoveIcon from '@mui/icons-material/Remove';
+import { Box } from '@mui/material';
+import { useState } from 'react';
+import { IconButton, NumberInput, NumberInputProps } from '../atoms';
+
+export interface NumberStepperProps extends Pick<NumberInputProps, 'size'> {
+  /** Valor numérico actual (controlado) */
+  value?: number;
+  /** Valor inicial cuando se usa sin control externo */
+  defaultValue?: number;
+  /** Manejador de cambio con el nuevo valor */
+  onChange?: (value: number) => void;
+  /** Valor mínimo permitido */
+  min?: number;
+  /** Valor máximo permitido */
+  max?: number;
+  /** Incremento/decremento por paso */
+  step?: number;
+  /** Deshabilita toda la interacción */
+  disabled?: boolean;
+}
+
+function clamp(value: number, min?: number, max?: number) {
+  if (min !== undefined) value = Math.max(min, value);
+  if (max !== undefined) value = Math.min(max, value);
+  return value;
+}
+
+/**
+ * Selector numérico con botones para aumentar o disminuir el valor.
+ */
+export function NumberStepper({
+  value,
+  defaultValue = 0,
+  onChange,
+  min,
+  max,
+  step = 1,
+  disabled = false,
+  size = 'medium',
+}: NumberStepperProps) {
+  const isControlled = value !== undefined;
+  const [internal, setInternal] = useState(defaultValue);
+  const current = isControlled ? value! : internal;
+
+  const updateValue = (val: number) => {
+    if (!isControlled) {
+      setInternal(val);
+    }
+    onChange?.(val);
+  };
+
+  const handleInputChange: NumberInputProps['onChange'] = (_, val) => {
+    if (val === '') return;
+    updateValue(clamp(val, min, max));
+  };
+
+  const handleBlur: React.FocusEventHandler<HTMLInputElement> = (e) => {
+    const numeric = Number(e.target.value);
+    const normalized = clamp(numeric, min, max);
+    if (numeric !== normalized) {
+      updateValue(normalized);
+    }
+  };
+
+  const increment = () => {
+    const next = clamp(current + step, min, max);
+    if (next !== current) {
+      updateValue(next);
+    }
+  };
+
+  const decrement = () => {
+    const next = clamp(current - step, min, max);
+    if (next !== current) {
+      updateValue(next);
+    }
+  };
+
+  const disableDec = disabled || (min !== undefined && current <= min);
+  const disableInc = disabled || (max !== undefined && current >= max);
+
+  return (
+    <Box display="flex" alignItems="center" gap={1}>
+      <IconButton
+        aria-label="decrement"
+        icon={<RemoveIcon />}
+        onClick={decrement}
+        disabled={disableDec}
+        size={size}
+      />
+      <NumberInput
+        value={current}
+        onChange={handleInputChange}
+        onBlur={handleBlur}
+        disabled={disabled}
+        min={min}
+        max={max}
+        size={size}
+        fullWidth={false}
+        inputProps={{ 'aria-label': 'current value', style: { textAlign: 'center' } }}
+        sx={{ width: size === 'small' ? 72 : 96 }}
+      />
+      <IconButton
+        aria-label="increment"
+        icon={<AddIcon />}
+        onClick={increment}
+        disabled={disableInc}
+        size={size}
+      />
+    </Box>
+  );
+}
+
+export default NumberStepper;

--- a/frontend/src/components/molecules/index.ts
+++ b/frontend/src/components/molecules/index.ts
@@ -6,3 +6,4 @@ export { LabeledCurrencyField } from './LabeledCurrencyField';
 export { RadioButtonGroup } from './RadioButtonGroup';
 export { ToggleSwitchField } from './ToggleSwitchField';
 export { SearchBar } from './SearchBar';
+export { NumberStepper } from './NumberStepper';


### PR DESCRIPTION
## Summary
- add new NumberStepper molecule with increment/decrement buttons
- document, test and export the component
- support uncontrolled usage via `defaultValue`

## Testing
- `pnpm --filter ./frontend run lint`
- `pnpm --filter ./frontend run test`


------
https://chatgpt.com/codex/tasks/task_e_684f222ec2fc832bbbad6bcdd9d2eb36