### PR TITLE
feat(ui): add DateRangePicker molecule

### DIFF
--- a/frontend/src/components/molecules/DateRangePicker.docs.mdx
+++ b/frontend/src/components/molecules/DateRangePicker.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './DateRangePicker.stories';
+import { DateRangePicker } from './DateRangePicker';
+
+<Meta of={Stories} />
+
+# DateRangePicker
+
+Selector de rango de fechas compuesto por dos `DatePicker`.
+
+<Story id="molecules-daterangepicker--default" />
+
+<ArgsTable of={DateRangePicker} story="Default" />

--- a/frontend/src/components/molecules/DateRangePicker.stories.tsx
+++ b/frontend/src/components/molecules/DateRangePicker.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import dayjs from 'dayjs';
+import { DateRangePicker } from './DateRangePicker';
+
+const meta: Meta<typeof DateRangePicker> = {
+  title: 'Molecules/DateRangePicker',
+  component: DateRangePicker,
+  args: {
+    start: null,
+    end: null,
+  },
+  argTypes: {
+    onChange: { action: 'changed' },
+    start: { control: 'date' },
+    end: { control: 'date' },
+    disabled: { control: 'boolean' },
+    startLabel: { control: 'text' },
+    endLabel: { control: 'text' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof DateRangePicker>;
+
+export const Default: Story = {};
+
+export const PredefinedRange: Story = {
+  args: {
+    start: dayjs().startOf('month'),
+    end: dayjs().startOf('month').add(14, 'day'),
+  },
+};
+
+export const Disabled: Story = {
+  args: { disabled: true },
+};
+
+export const WithLabels: Story = {
+  args: { startLabel: 'Desde', endLabel: 'Hasta' },
+};
+
+export const ErrorExample: Story = {
+  args: {
+    start: dayjs('2025-01-10'),
+    end: dayjs('2025-01-05'),
+  },
+};

--- a/frontend/src/components/molecules/DateRangePicker.test.tsx
+++ b/frontend/src/components/molecules/DateRangePicker.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import dayjs from 'dayjs';
+import React from 'react';
+import { ThemeProvider } from '../../theme';
+import { DateRangePicker, DateRange } from './DateRangePicker';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+function Wrapper(
+  props: Omit<React.ComponentProps<typeof DateRangePicker>, 'start' | 'end'>,
+) {
+  const [range, setRange] = React.useState<DateRange>({ start: null, end: null });
+  return (
+    <DateRangePicker
+      start={range.start}
+      end={range.end}
+      onChange={(r) => {
+        setRange(r);
+        props.onChange?.(r);
+      }}
+      {...props}
+    />
+  );
+}
+
+describe('DateRangePicker', () => {
+  it('renders both date pickers', () => {
+    renderWithTheme(<DateRangePicker start={null} end={null} onChange={() => {}} />);
+    expect(screen.getAllByLabelText('Desde')[0]).toBeInTheDocument();
+    expect(screen.getAllByLabelText('Hasta')[0]).toBeInTheDocument();
+  });
+
+  it('emits full range on selecting start then end', async () => {
+    const user = userEvent.setup();
+    const handleChange = jest.fn();
+    renderWithTheme(<Wrapper onChange={handleChange} />);
+    const startRoot = screen.getAllByLabelText('Desde')[0];
+    await user.type(startRoot, '01/05/2024');
+    fireEvent.blur(startRoot);
+    const endRoot = screen.getAllByLabelText('Hasta')[0];
+    await user.type(endRoot, '01/10/2024');
+    fireEvent.blur(endRoot);
+    expect(handleChange).toHaveBeenCalled();
+  });
+
+  it('shows error when start is after end', () => {
+    const start = dayjs('2025-01-10');
+    const end = dayjs('2025-01-05');
+    renderWithTheme(<DateRangePicker start={start} end={end} onChange={() => {}} />);
+    const startInput = screen.getAllByLabelText('Desde')[0];
+    const endInput = screen.getAllByLabelText('Hasta')[0];
+    expect(startInput).toHaveAttribute('aria-invalid', 'true');
+    expect(endInput).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('is disabled when prop disabled', async () => {
+    const user = userEvent.setup();
+    renderWithTheme(
+      <DateRangePicker start={null} end={null} onChange={() => {}} disabled />,
+    );
+    const startInput = screen.getAllByLabelText('Desde')[0];
+    await user.click(startInput);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/molecules/DateRangePicker.tsx
+++ b/frontend/src/components/molecules/DateRangePicker.tsx
@@ -1,0 +1,81 @@
+import { Box, Typography } from '@mui/material';
+import { ReactNode } from 'react';
+import { Dayjs } from 'dayjs';
+import { DatePicker, DatePickerProps } from '../atoms';
+
+export interface DateRange {
+  /** Fecha inicial del rango */
+  start: Dayjs | null;
+  /** Fecha final del rango */
+  end: Dayjs | null;
+}
+
+export interface DateRangePickerProps {
+  /** Fecha inicial seleccionada */
+  start: Dayjs | null;
+  /** Fecha final seleccionada */
+  end: Dayjs | null;
+  /** Callback ejecutado al cambiar alguna de las fechas */
+  onChange: (range: DateRange) => void;
+  /** Deshabilita todo el componente */
+  disabled?: boolean;
+  /** Texto de la etiqueta para la fecha inicial */
+  startLabel?: string;
+  /** Texto de la etiqueta para la fecha final */
+  endLabel?: string;
+  /** Elemento que separa visualmente ambas fechas */
+  separator?: ReactNode;
+}
+
+/**
+ * Selector de rango de fechas basado en dos `DatePicker`.
+ * Muestra error cuando la fecha inicial es posterior a la final.
+ */
+export function DateRangePicker({
+  start,
+  end,
+  onChange,
+  disabled = false,
+  startLabel = 'Desde',
+  endLabel = 'Hasta',
+  separator = '–',
+}: DateRangePickerProps) {
+  const rangeError = Boolean(start && end && start.isAfter(end));
+
+  const handleStartChange: NonNullable<DatePickerProps['onChange']> = (value) => {
+    onChange({ start: value, end });
+  };
+
+  const handleEndChange: NonNullable<DatePickerProps['onChange']> = (value) => {
+    onChange({ start, end: value });
+  };
+
+  const separatorNode =
+    typeof separator === 'string' ? (
+      <Typography sx={{ mx: 1 }}>{separator}</Typography>
+    ) : (
+      separator
+    );
+
+  return (
+    <Box display="flex" alignItems="center" gap={1}>
+      <DatePicker
+        label={startLabel}
+        value={start}
+        onChange={handleStartChange}
+        disabled={disabled}
+        slotProps={{ textField: { error: rangeError } }}
+      />
+      {separatorNode}
+      <DatePicker
+        label={endLabel}
+        value={end}
+        onChange={handleEndChange}
+        disabled={disabled}
+        slotProps={{ textField: { error: rangeError } }}
+      />
+    </Box>
+  );
+}
+
+export default DateRangePicker;

--- a/frontend/src/components/molecules/index.ts
+++ b/frontend/src/components/molecules/index.ts
@@ -7,3 +7,4 @@ export { RadioButtonGroup } from './RadioButtonGroup';
 export { ToggleSwitchField } from './ToggleSwitchField';
 export { SearchBar } from './SearchBar';
 export { NumberStepper } from './NumberStepper';
+export { DateRangePicker } from './DateRangePicker';


### PR DESCRIPTION
## Summary
- create `DateRangePicker` molecule combining two `DatePicker` atoms
- add Storybook docs and stories for the new component
- test interactions and error/disabled states
- export component in molecules index

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684f2f659de0832b93ea3e779e19d5a1