### PR TITLE
Add AvatarName molecule

### DIFF
--- a/frontend/src/components/molecules/AvatarName.docs.mdx
+++ b/frontend/src/components/molecules/AvatarName.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './AvatarName.stories';
+import { AvatarName } from './AvatarName';
+
+<Meta of={Stories} />
+
+# AvatarName
+
+Componente que muestra un avatar junto al nombre de usuario.
+
+<Story id="molecules-avatarname--horizontal" />
+
+<ArgsTable of={AvatarName} story="Horizontal" />

--- a/frontend/src/components/molecules/AvatarName.stories.tsx
+++ b/frontend/src/components/molecules/AvatarName.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { AvatarName } from './AvatarName';
+
+const meta: Meta<typeof AvatarName> = {
+  title: 'Molecules/AvatarName',
+  component: AvatarName,
+  args: {
+    name: 'Ana Gómez',
+    src: 'https://i.pravatar.cc/40',
+    size: 'medium',
+    orientation: 'horizontal',
+  },
+  argTypes: {
+    src: { control: 'text' },
+    name: { control: 'text' },
+    orientation: { control: 'radio', options: ['horizontal', 'vertical'] },
+    size: { control: 'select', options: ['small', 'medium', 'large'] },
+    variant: { control: 'select', options: ['circular', 'rounded', 'square'] },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof AvatarName>;
+
+export const Horizontal: Story = {};
+
+export const Vertical: Story = {
+  args: { orientation: 'vertical' },
+};
+
+export const NoImage: Story = {
+  args: { src: undefined },
+};

--- a/frontend/src/components/molecules/AvatarName.test.tsx
+++ b/frontend/src/components/molecules/AvatarName.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider } from '../../theme';
+import { AvatarName } from './AvatarName';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('AvatarName', () => {
+  it('renders avatar image when src provided', () => {
+    renderWithTheme(<AvatarName name="Juan" src="avatar.png" />);
+    const img = screen.getByRole('img', { name: /juan/i });
+    expect(img).toHaveAttribute('src', 'avatar.png');
+  });
+
+  it('renders initials when no image', () => {
+    renderWithTheme(<AvatarName name="Juan Perez" />);
+    expect(screen.getByText('JP')).toBeInTheDocument();
+  });
+
+  it('displays the name', () => {
+    renderWithTheme(<AvatarName name="Maria" />);
+    expect(screen.getByText('Maria')).toBeInTheDocument();
+  });
+
+  it('applies vertical orientation', () => {
+    const { container } = renderWithTheme(
+      <AvatarName name="Ana" orientation="vertical" />,
+    );
+    const root = container.firstChild as HTMLElement;
+    expect(root).toHaveStyle({ flexDirection: 'column' });
+  });
+
+  it('applies size styles', () => {
+    const { getByText } = renderWithTheme(<AvatarName name="Bob" size="small" />);
+    const avatar = getByText('B');
+    expect(avatar).toHaveStyle({ width: '32px', height: '32px' });
+  });
+});

--- a/frontend/src/components/molecules/AvatarName.tsx
+++ b/frontend/src/components/molecules/AvatarName.tsx
@@ -1,0 +1,46 @@
+import { Box, Typography } from '@mui/material';
+import { Avatar, AvatarProps } from '../atoms';
+
+export interface AvatarNameProps extends Omit<AvatarProps, 'children'> {
+  /** Nombre a mostrar junto al avatar */
+  name: string;
+  /** Orientación del layout */
+  orientation?: 'horizontal' | 'vertical';
+}
+
+/**
+ * Muestra un avatar con el nombre del usuario o cliente.
+ */
+export function AvatarName({
+  name,
+  orientation = 'horizontal',
+  size = 'medium',
+  src,
+  ...avatarProps
+}: AvatarNameProps) {
+  const initials =
+    !src && name
+      ? name
+          .split(/\s+/)
+          .map((w) => w[0])
+          .slice(0, 2)
+          .join('')
+          .toUpperCase()
+      : undefined;
+
+  return (
+    <Box
+      display="flex"
+      alignItems="center"
+      flexDirection={orientation === 'vertical' ? 'column' : 'row'}
+      gap={1}
+    >
+      <Avatar alt={name} src={src} size={size} {...avatarProps}>
+        {initials}
+      </Avatar>
+      <Typography variant="body1">{name}</Typography>
+    </Box>
+  );
+}
+
+export default AvatarName;

--- a/frontend/src/components/molecules/index.ts
+++ b/frontend/src/components/molecules/index.ts
@@ -8,3 +8,4 @@ export { ToggleSwitchField } from './ToggleSwitchField';
 export { SearchBar } from './SearchBar';
 export { NumberStepper } from './NumberStepper';
 export { DateRangePicker } from './DateRangePicker';
+export { AvatarName } from './AvatarName';


### PR DESCRIPTION
## Summary
- add AvatarName molecule component
- document AvatarName in Storybook
- test AvatarName behavior
- export AvatarName from molecules index

## Testing
- `npm run lint` within `frontend`
- `npm test` within `frontend`


------
https://chatgpt.com/codex/tasks/task_e_684f8ab6d7d8832bb30be1a34446deed