### PR TITLE
feat(ui): add AvatarStatus molecule

### DIFF
--- a/frontend/src/components/molecules/AvatarStatus.docs.mdx
+++ b/frontend/src/components/molecules/AvatarStatus.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './AvatarStatus.stories';
+import { AvatarStatus } from './AvatarStatus';
+
+<Meta of={Stories} />
+
+# AvatarStatus
+
+Molecula que combina un avatar con un indicador de estado.
+
+<Story id="molecules-avatarstatus--online" />
+
+<ArgsTable of={AvatarStatus} story="Online" />

--- a/frontend/src/components/molecules/AvatarStatus.stories.tsx
+++ b/frontend/src/components/molecules/AvatarStatus.stories.tsx
@@ -1,0 +1,53 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { AvatarStatus } from './AvatarStatus';
+
+const meta: Meta<typeof AvatarStatus> = {
+  title: 'Molecules/AvatarStatus',
+  component: AvatarStatus,
+  args: {
+    name: 'Ana Gómez',
+    src: 'https://i.pravatar.cc/40',
+    status: 'online',
+    size: 'medium',
+    position: 'bottom-right',
+  },
+  argTypes: {
+    status: { control: 'select', options: ['online', 'offline', 'away', 'busy'] },
+    position: {
+      control: 'select',
+      options: ['top-left', 'top-right', 'bottom-left', 'bottom-right'],
+    },
+    size: { control: 'select', options: ['small', 'medium', 'large'] },
+    src: { control: 'text' },
+    name: { control: 'text' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof AvatarStatus>;
+
+export const Online: Story = {};
+
+export const Offline: Story = {
+  args: { status: 'offline' },
+};
+
+export const Away: Story = {
+  args: { status: 'away' },
+};
+
+export const Busy: Story = {
+  args: { status: 'busy' },
+};
+
+export const CustomPosition: Story = {
+  args: { position: 'top-left' },
+};
+
+export const NoImage: Story = {
+  args: { src: undefined },
+};
+
+export const Large: Story = {
+  args: { size: 'large' },
+};

--- a/frontend/src/components/molecules/AvatarStatus.test.tsx
+++ b/frontend/src/components/molecules/AvatarStatus.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider } from '../../theme';
+import { AvatarStatus } from './AvatarStatus';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('AvatarStatus', () => {
+  it('positions badge at bottom right by default', () => {
+    const { container } = renderWithTheme(<AvatarStatus name="Ana" status="online" />);
+    const badge = container.querySelector('.MuiBadge-badge') as HTMLElement;
+    expect(badge).toHaveClass('MuiBadge-anchorOriginBottomRightCircular');
+  });
+
+  it('applies color class for online status', () => {
+    const { container } = renderWithTheme(<AvatarStatus name="Bob" status="online" />);
+    const badge = container.querySelector('.MuiBadge-badge') as HTMLElement;
+    expect(badge).toHaveClass('MuiBadge-colorSuccess');
+  });
+
+  it('shows initials when no image', () => {
+    renderWithTheme(<AvatarStatus name="Carlos Perez" status="offline" />);
+    expect(screen.getByText('CP')).toBeInTheDocument();
+  });
+
+  it('applies custom badge position', () => {
+    const { container } = renderWithTheme(
+      <AvatarStatus name="Dana" status="away" position="top-left" />,
+    );
+    const badge = container.querySelector('.MuiBadge-badge') as HTMLElement;
+    expect(badge).toHaveClass('MuiBadge-anchorOriginTopLeftCircular');
+  });
+
+  it('respects avatar size', () => {
+    const { container } = renderWithTheme(
+      <AvatarStatus name="Ema" status="busy" size="large" />,
+    );
+    const avatar = container.querySelector('.MuiAvatar-root') as HTMLElement;
+    expect(avatar).toHaveStyle({ width: '64px', height: '64px' });
+  });
+});

--- a/frontend/src/components/molecules/AvatarStatus.tsx
+++ b/frontend/src/components/molecules/AvatarStatus.tsx
@@ -1,0 +1,62 @@
+import { Badge } from '../atoms/Badge';
+import { Avatar, AvatarProps } from '../atoms';
+
+export interface AvatarStatusProps extends Omit<AvatarProps, 'children'> {
+  /** Nombre del usuario para generar iniciales. */
+  name: string;
+  /** Estado actual representado por el badge. */
+  status?: 'online' | 'offline' | 'away' | 'busy';
+  /** Posición del indicador de estado. */
+  position?: 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left';
+}
+
+const STATUS_COLOR_MAP = {
+  online: 'success',
+  offline: 'default',
+  away: 'warning',
+  busy: 'error',
+} as const;
+
+/**
+ * Muestra un avatar con un badge que refleja el estado del usuario.
+ */
+export function AvatarStatus({
+  name,
+  status = 'offline',
+  position = 'bottom-right',
+  src,
+  size = 'medium',
+  ...avatarProps
+}: AvatarStatusProps) {
+  const initials =
+    !src && name
+      ? name
+          .split(/\s+/)
+          .map((w) => w[0])
+          .slice(0, 2)
+          .join('')
+          .toUpperCase()
+      : undefined;
+
+  const [vertical, horizontal] = position.split('-') as [
+    'top' | 'bottom',
+    'left' | 'right',
+  ];
+
+  return (
+    <Badge
+      content={0}
+      variant="dot"
+      overlap="circular"
+      color={STATUS_COLOR_MAP[status]}
+      anchorOrigin={{ vertical, horizontal }}
+      showZero
+    >
+      <Avatar alt={name} src={src} size={size} {...avatarProps}>
+        {initials}
+      </Avatar>
+    </Badge>
+  );
+}
+
+export default AvatarStatus;

--- a/frontend/src/components/molecules/index.ts
+++ b/frontend/src/components/molecules/index.ts
@@ -9,3 +9,4 @@ export { SearchBar } from './SearchBar';
 export { NumberStepper } from './NumberStepper';
 export { DateRangePicker } from './DateRangePicker';
 export { AvatarName } from './AvatarName';
+export { AvatarStatus } from './AvatarStatus';


### PR DESCRIPTION
## Summary
- add `AvatarStatus` molecule with status badge
- document component and storybook stories
- add tests for positioning, color and scaling
- export from molecules index

## Testing
- `pnpm --filter ./frontend lint`
- `pnpm --filter ./frontend test`


------
https://chatgpt.com/codex/tasks/task_e_684f8c2a6984832bb938082d99792f53