### PR TITLE
feat(ui): add UserInfoDisplay molecule

### DIFF
--- a/frontend/src/components/molecules/UserInfoDisplay.docs.mdx
+++ b/frontend/src/components/molecules/UserInfoDisplay.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './UserInfoDisplay.stories';
+import { UserInfoDisplay } from './UserInfoDisplay';
+
+<Meta of={Stories} />
+
+# UserInfoDisplay
+
+Molecula que presenta información resumida de un usuario.
+
+<Story id="molecules-userinfodisplay--horizontal" />
+
+<ArgsTable of={UserInfoDisplay} story="Horizontal" />

--- a/frontend/src/components/molecules/UserInfoDisplay.stories.tsx
+++ b/frontend/src/components/molecules/UserInfoDisplay.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { UserInfoDisplay } from './UserInfoDisplay';
+
+const meta: Meta<typeof UserInfoDisplay> = {
+  title: 'Molecules/UserInfoDisplay',
+  component: UserInfoDisplay,
+  args: {
+    name: 'Ana Gómez',
+    secondaryInfo: 'Vendedora',
+    src: 'https://i.pravatar.cc/40',
+    orientation: 'horizontal',
+    chipLabel: 'VIP',
+    size: 'medium',
+  },
+  argTypes: {
+    orientation: { control: 'radio', options: ['horizontal', 'vertical'] },
+    size: { control: 'select', options: ['small', 'medium', 'large'] },
+    src: { control: 'text' },
+    name: { control: 'text' },
+    secondaryInfo: { control: 'text' },
+    chipLabel: { control: 'text' },
+    loading: { control: 'boolean' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof UserInfoDisplay>;
+
+export const Horizontal: Story = {};
+
+export const Vertical: Story = {
+  args: { orientation: 'vertical' },
+};
+
+export const NoImage: Story = {
+  args: { src: undefined },
+};
+
+export const WithoutSecondary: Story = {
+  args: { secondaryInfo: undefined },
+};
+
+export const Loading: Story = {
+  args: { loading: true },
+};

--- a/frontend/src/components/molecules/UserInfoDisplay.test.tsx
+++ b/frontend/src/components/molecules/UserInfoDisplay.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider } from '../../theme';
+import { UserInfoDisplay } from './UserInfoDisplay';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('UserInfoDisplay', () => {
+  it('renders avatar, name and secondary info', () => {
+    renderWithTheme(
+      <UserInfoDisplay
+        name="Juan Perez"
+        secondaryInfo="Administrador"
+        src="avatar.png"
+      />,
+    );
+    expect(screen.getByRole('img', { name: /juan perez/i })).toHaveAttribute(
+      'src',
+      'avatar.png',
+    );
+    expect(screen.getByText('Juan Perez')).toBeInTheDocument();
+    expect(screen.getByText('Administrador')).toBeInTheDocument();
+  });
+
+  it('handles missing secondary info', () => {
+    renderWithTheme(<UserInfoDisplay name="Ana" />);
+    expect(screen.queryByText('Ana', { selector: 'p' })).toBeInTheDocument();
+    // should not render additional text nodes beyond the name
+    const paragraphs = screen.getAllByText('Ana');
+    expect(paragraphs).toHaveLength(1);
+  });
+
+  it('shows initials when no image', () => {
+    renderWithTheme(<UserInfoDisplay name="Ana Gomez" />);
+    expect(screen.getByText('AG')).toBeInTheDocument();
+  });
+
+  it('applies vertical orientation', () => {
+    const { container } = renderWithTheme(
+      <UserInfoDisplay name="Bob" orientation="vertical" />,
+    );
+    const root = container.firstChild as HTMLElement;
+    expect(root).toHaveStyle({ flexDirection: 'column' });
+  });
+
+  it('renders skeletons when loading', () => {
+    const { queryByTestId } = renderWithTheme(
+      <UserInfoDisplay name="Loading" loading />,
+    );
+    expect(queryByTestId('avatar-skeleton')).toBeInTheDocument();
+    expect(queryByTestId('name-skeleton')).toBeInTheDocument();
+    expect(screen.queryByText('Loading')).toBeNull();
+  });
+});

--- a/frontend/src/components/molecules/UserInfoDisplay.tsx
+++ b/frontend/src/components/molecules/UserInfoDisplay.tsx
@@ -1,0 +1,92 @@
+import { Box, Typography, Skeleton } from '@mui/material';
+import { Avatar, AvatarProps, Chip } from '../atoms';
+
+export interface UserInfoDisplayProps extends Omit<AvatarProps, 'children'> {
+  /** Nombre completo del usuario */
+  name: string;
+  /** Dato secundario a mostrar (rol, email, etc.) */
+  secondaryInfo?: string;
+  /** Orientación del layout */
+  orientation?: 'horizontal' | 'vertical';
+  /** Texto opcional a mostrar dentro de un chip */
+  chipLabel?: string;
+  /** Muestra esqueletos de carga en lugar de la info real */
+  loading?: boolean;
+}
+
+const SIZE_MAP = {
+  small: 32,
+  medium: 40,
+  large: 64,
+} as const;
+
+/**
+ * Muestra un avatar acompañado del nombre y un dato secundario.
+ * Puede incluir un `Chip` destacado y un estado de carga.
+ */
+export function UserInfoDisplay({
+  name,
+  secondaryInfo,
+  orientation = 'horizontal',
+  chipLabel,
+  loading = false,
+  size = 'medium',
+  src,
+  ...avatarProps
+}: UserInfoDisplayProps) {
+  const initials =
+    !src && name
+      ? name
+          .split(/\s+/)
+          .map((w) => w[0])
+          .slice(0, 2)
+          .join('')
+          .toUpperCase()
+      : undefined;
+
+  const dimension = SIZE_MAP[size] ?? 40;
+
+  return (
+    <Box
+      display="flex"
+      alignItems="center"
+      flexDirection={orientation === 'vertical' ? 'column' : 'row'}
+      gap={1}
+    >
+      {loading ? (
+        <Skeleton
+          variant="circular"
+          width={dimension}
+          height={dimension}
+          data-testid="avatar-skeleton"
+        />
+      ) : (
+        <Avatar alt={name} src={src} size={size} {...avatarProps}>
+          {initials}
+        </Avatar>
+      )}
+      <Box
+        display="flex"
+        flexDirection="column"
+        textAlign={orientation === 'vertical' ? 'center' : 'left'}
+        alignItems={orientation === 'vertical' ? 'center' : 'flex-start'}
+      >
+        {loading ? (
+          <Skeleton width={80} data-testid="name-skeleton" />
+        ) : (
+          <Typography variant="body1" noWrap>
+            {name}
+          </Typography>
+        )}
+        {!loading && secondaryInfo && (
+          <Typography variant="body2" color="text.secondary" noWrap>
+            {secondaryInfo}
+          </Typography>
+        )}
+        {!loading && chipLabel && <Chip label={chipLabel} size="small" />}
+      </Box>
+    </Box>
+  );
+}
+
+export default UserInfoDisplay;

--- a/frontend/src/components/molecules/index.ts
+++ b/frontend/src/components/molecules/index.ts
@@ -10,3 +10,4 @@ export { NumberStepper } from './NumberStepper';
 export { DateRangePicker } from './DateRangePicker';
 export { AvatarName } from './AvatarName';
 export { AvatarStatus } from './AvatarStatus';
+export { UserInfoDisplay } from './UserInfoDisplay';


### PR DESCRIPTION
## Summary
- add `UserInfoDisplay` molecule with optional chip and loading state
- document component in MDX and Storybook stories
- cover new molecule with tests
- export from molecules index

## Testing
- `pnpm --filter ./frontend lint`
- `pnpm --filter ./frontend test`

------
https://chatgpt.com/codex/tasks/task_e_684f9d22f7e8832bbc381c8470d4817d