### PR TITLE
feat(ui): add StatusBadgeDisplay molecule

### DIFF
--- a/frontend/src/components/molecules/StatusBadgeDisplay.docs.mdx
+++ b/frontend/src/components/molecules/StatusBadgeDisplay.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './StatusBadgeDisplay.stories';
+import { StatusBadgeDisplay } from './StatusBadgeDisplay';
+
+<Meta of={Stories} />
+
+# StatusBadgeDisplay
+
+Molecula que combina un indicador de estado con texto descriptivo.
+
+<Story id="molecules-statusbadgedisplay--active" />
+
+<ArgsTable of={StatusBadgeDisplay} story="Active" />

--- a/frontend/src/components/molecules/StatusBadgeDisplay.stories.tsx
+++ b/frontend/src/components/molecules/StatusBadgeDisplay.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { StatusBadgeDisplay } from './StatusBadgeDisplay';
+
+const meta: Meta<typeof StatusBadgeDisplay> = {
+  title: 'Molecules/StatusBadgeDisplay',
+  component: StatusBadgeDisplay,
+  args: {
+    label: 'Activo',
+    status: 'success',
+    badgePosition: 'start',
+    size: 'medium',
+  },
+  argTypes: {
+    status: {
+      control: 'select',
+      options: ['success', 'warning', 'error', 'info', 'default'],
+    },
+    badgePosition: { control: 'radio', options: ['start', 'end'] },
+    size: { control: 'select', options: ['small', 'medium'] },
+    label: { control: 'text' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof StatusBadgeDisplay>;
+
+export const Active: Story = {};
+
+export const Pending: Story = {
+  args: { status: 'warning', label: 'Pendiente' },
+};
+
+export const Inactive: Story = {
+  args: { status: 'default', label: 'Inactivo' },
+};
+
+export const ErrorState: Story = {
+  args: { status: 'error', label: 'Error' },
+};
+
+export const Info: Story = {
+  args: { status: 'info', label: 'Info' },
+};
+
+export const EndPosition: Story = {
+  args: { badgePosition: 'end' },
+};
+
+export const Compact: Story = {
+  args: { label: '' },
+};
+
+export const Small: Story = {
+  args: { size: 'small' },
+};

--- a/frontend/src/components/molecules/StatusBadgeDisplay.test.tsx
+++ b/frontend/src/components/molecules/StatusBadgeDisplay.test.tsx
@@ -1,0 +1,48 @@
+import { render } from '@testing-library/react';
+import { ThemeProvider } from '../../theme';
+import { StatusBadgeDisplay } from './StatusBadgeDisplay';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('StatusBadgeDisplay', () => {
+  const statuses = ['success', 'warning', 'error', 'info'] as const;
+
+  statuses.forEach((status) => {
+    it(`applies color class for ${status} status`, () => {
+      const { container } = renderWithTheme(
+        <StatusBadgeDisplay label="Estado" status={status} />,
+      );
+      const badge = container.querySelector('.MuiBadge-badge') as HTMLElement;
+      const capitalized = status.charAt(0).toUpperCase() + status.slice(1);
+      expect(badge).toHaveClass(`MuiBadge-color${capitalized}`);
+    });
+  });
+
+  it('renders badge before text by default', () => {
+    const { container } = renderWithTheme(
+      <StatusBadgeDisplay label="Activo" status="success" />,
+    );
+    const wrapper = container.firstChild as HTMLElement;
+    const style = window.getComputedStyle(wrapper);
+    expect(style.flexDirection).toBe('row');
+  });
+
+  it('renders badge after text when badgePosition="end"', () => {
+    const { container } = renderWithTheme(
+      <StatusBadgeDisplay label="Activo" status="success" badgePosition="end" />,
+    );
+    const wrapper = container.firstChild as HTMLElement;
+    const style = window.getComputedStyle(wrapper);
+    expect(style.flexDirection).toBe('row-reverse');
+  });
+
+  it('renders only badge when label is empty', () => {
+    const { container } = renderWithTheme(
+      <StatusBadgeDisplay label="" status="success" />,
+    );
+    expect(container.querySelector('.MuiBadge-root')).toBeInTheDocument();
+    expect(container.querySelector('.MuiTypography-root')).toBeNull();
+  });
+});

--- a/frontend/src/components/molecules/StatusBadgeDisplay.tsx
+++ b/frontend/src/components/molecules/StatusBadgeDisplay.tsx
@@ -1,0 +1,70 @@
+import { Box, Typography } from '@mui/material';
+import { Badge } from '../atoms';
+
+export interface StatusBadgeDisplayProps {
+  /**
+   * Texto a mostrar junto al badge. Si se omite, solo se renderiza el badge.
+   */
+  label?: string;
+  /** Estado que determina el color del badge. */
+  status?: 'success' | 'warning' | 'error' | 'info' | 'default';
+  /** Posicion del badge respecto al texto. */
+  badgePosition?: 'start' | 'end';
+  /** Tamaño del punto indicador. */
+  size?: 'small' | 'medium';
+}
+
+const SIZE_MAP = {
+  small: 8,
+  medium: 12,
+} as const;
+
+const STATUS_COLOR_MAP = {
+  success: 'success',
+  warning: 'warning',
+  error: 'error',
+  info: 'info',
+  default: 'default',
+} as const;
+
+/**
+ * Muestra un punto de estado junto a una etiqueta descriptiva.
+ */
+export function StatusBadgeDisplay({
+  label,
+  status = 'info',
+  badgePosition = 'start',
+  size = 'medium',
+}: StatusBadgeDisplayProps) {
+  const dotSize = SIZE_MAP[size];
+
+  const badge = (
+    <Badge
+      content={0}
+      variant="dot"
+      color={STATUS_COLOR_MAP[status]}
+      showZero
+      slotProps={{ badge: { sx: { height: dotSize, minWidth: dotSize } } }}
+    >
+      <Box sx={{ width: 0, height: 0 }} />
+    </Badge>
+  );
+
+  if (!label) {
+    return badge;
+  }
+
+  return (
+    <Box
+      display="flex"
+      alignItems="center"
+      gap={0.5}
+      flexDirection={badgePosition === 'end' ? 'row-reverse' : 'row'}
+    >
+      {badge}
+      <Typography variant="body2">{label}</Typography>
+    </Box>
+  );
+}
+
+export default StatusBadgeDisplay;

--- a/frontend/src/components/molecules/index.ts
+++ b/frontend/src/components/molecules/index.ts
@@ -11,3 +11,4 @@ export { DateRangePicker } from './DateRangePicker';
 export { AvatarName } from './AvatarName';
 export { AvatarStatus } from './AvatarStatus';
 export { UserInfoDisplay } from './UserInfoDisplay';
+export { StatusBadgeDisplay } from './StatusBadgeDisplay';


### PR DESCRIPTION
## Summary
- create `StatusBadgeDisplay` molecule using existing Badge atom and Typography
- add unit tests for all states and variations
- document the component in Storybook
- export the molecule from components index

## Testing
- `pytest`
- `pnpm --filter ./frontend test`

------
https://chatgpt.com/codex/tasks/task_e_685036b78bc4832bb3627d7acbcd7b84