### PR TITLE
feat(frontend): add IconWithBadge molecule

### DIFF
--- a/frontend/src/components/molecules/IconWithBadge.docs.mdx
+++ b/frontend/src/components/molecules/IconWithBadge.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './IconWithBadge.stories';
+import { IconWithBadge } from './IconWithBadge';
+
+<Meta of={Stories} />
+
+# IconWithBadge
+
+Ícono con badge superpuesto para notificaciones o conteos.
+
+<Story id="molecules-iconwithbadge--default" />
+
+<ArgsTable of={IconWithBadge} story="Default" />

--- a/frontend/src/components/molecules/IconWithBadge.stories.tsx
+++ b/frontend/src/components/molecules/IconWithBadge.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import NotificationsIcon from '@mui/icons-material/Notifications';
+import { IconWithBadge } from './IconWithBadge';
+
+const meta: Meta<typeof IconWithBadge> = {
+  title: 'Molecules/IconWithBadge',
+  component: IconWithBadge,
+  args: {
+    icon: <NotificationsIcon />,
+    label: 'notificaciones',
+    count: 3,
+    badgeColor: 'error',
+    variant: 'standard',
+    position: 'top-right',
+    size: 'medium',
+  },
+  argTypes: {
+    name: {
+      control: 'select',
+      options: ['search', 'user', 'settings', 'menu', 'close', 'delete', 'favorite'],
+    },
+    icon: { control: false },
+    color: {
+      control: 'select',
+      options: [
+        'inherit',
+        'primary',
+        'secondary',
+        'action',
+        'disabled',
+        'error',
+        'info',
+        'success',
+        'warning',
+      ],
+    },
+    size: { control: 'select', options: ['inherit', 'small', 'medium', 'large'] },
+    count: { control: 'number' },
+    badgeColor: {
+      control: 'select',
+      options: ['primary', 'secondary', 'error', 'info', 'success', 'warning'],
+    },
+    variant: { control: 'select', options: ['standard', 'dot'] },
+    showZero: { control: 'boolean' },
+    max: { control: 'number' },
+    position: {
+      control: 'select',
+      options: ['top-left', 'top-right', 'bottom-left', 'bottom-right'],
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof IconWithBadge>;
+
+export const Default: Story = {};
+export const NoNotifications: Story = { args: { count: 0 } };
+export const Many: Story = { args: { count: 120, max: 99 } };
+export const DotVariant: Story = { args: { variant: 'dot' } };

--- a/frontend/src/components/molecules/IconWithBadge.test.tsx
+++ b/frontend/src/components/molecules/IconWithBadge.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from '@testing-library/react';
+import NotificationsIcon from '@mui/icons-material/Notifications';
+import { ThemeProvider } from '../../theme';
+import { IconWithBadge } from './IconWithBadge';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('IconWithBadge', () => {
+  it('hides badge when count is zero by default', () => {
+    const { container } = renderWithTheme(
+      <IconWithBadge icon={<NotificationsIcon />} label="notificaciones" />,
+    );
+    const badge = container.querySelector('.MuiBadge-badge') as HTMLElement;
+    expect(badge).toHaveClass('MuiBadge-invisible');
+  });
+
+  it('shows badge with count text', () => {
+    renderWithTheme(
+      <IconWithBadge icon={<NotificationsIcon />} label="notificaciones" count={5} />,
+    );
+    expect(screen.getByText('5')).toBeInTheDocument();
+  });
+
+  it('shows overflow text when count exceeds max', () => {
+    renderWithTheme(
+      <IconWithBadge
+        icon={<NotificationsIcon />}
+        count={150}
+        max={99}
+        label="notificaciones"
+      />,
+    );
+    expect(screen.getByText('99+')).toBeInTheDocument();
+  });
+
+  it('applies custom position class', () => {
+    const { container } = renderWithTheme(
+      <IconWithBadge
+        icon={<NotificationsIcon />}
+        count={1}
+        position="bottom-left"
+        label="notificaciones"
+      />,
+    );
+    const badge = container.querySelector('.MuiBadge-badge') as HTMLElement;
+    expect(badge).toHaveClass('MuiBadge-anchorOriginBottomLeftCircular');
+  });
+
+  it('sets combined aria-label', () => {
+    renderWithTheme(
+      <IconWithBadge icon={<NotificationsIcon />} label="notificaciones" count={2} />,
+    );
+    expect(screen.getByLabelText('2 notificaciones')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/molecules/IconWithBadge.tsx
+++ b/frontend/src/components/molecules/IconWithBadge.tsx
@@ -1,0 +1,56 @@
+import { Badge, BadgeProps } from '../atoms/Badge';
+import { Icon, IconProps } from '../atoms/Icon';
+
+export interface IconWithBadgeProps extends IconProps {
+  /** Conteo a mostrar en el badge. */
+  count?: number;
+  /** Texto base para accesibilidad. */
+  label?: string;
+  /** Color del badge. */
+  badgeColor?: BadgeProps['color'];
+  /** Variante del badge. */
+  variant?: BadgeProps['variant'];
+  /** Mostrar "0" cuando count es cero. */
+  showZero?: boolean;
+  /** Valor máximo antes de overflow. */
+  max?: number;
+  /** Posición del badge. */
+  position?: 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left';
+}
+
+/**
+ * Ícono con un badge superpuesto para notificaciones o conteos.
+ */
+export function IconWithBadge({
+  count = 0,
+  label,
+  badgeColor = 'error',
+  variant = 'standard',
+  showZero = false,
+  max,
+  position = 'top-right',
+  ...iconProps
+}: IconWithBadgeProps) {
+  const [vertical, horizontal] = position.split('-') as [
+    'top' | 'bottom',
+    'left' | 'right',
+  ];
+
+  const ariaLabel = label ? (count > 0 ? `${count} ${label}` : label) : undefined;
+
+  return (
+    <Badge
+      content={variant === 'dot' ? 0 : count}
+      color={badgeColor}
+      variant={variant}
+      showZero={showZero}
+      max={max}
+      anchorOrigin={{ vertical, horizontal }}
+      overlap="circular"
+    >
+      <Icon aria-label={ariaLabel} {...iconProps} />
+    </Badge>
+  );
+}
+
+export default IconWithBadge;

--- a/frontend/src/components/molecules/index.ts
+++ b/frontend/src/components/molecules/index.ts
@@ -12,3 +12,4 @@ export { AvatarName } from './AvatarName';
 export { AvatarStatus } from './AvatarStatus';
 export { UserInfoDisplay } from './UserInfoDisplay';
 export { StatusBadgeDisplay } from './StatusBadgeDisplay';
+export { IconWithBadge } from './IconWithBadge';


### PR DESCRIPTION
## Summary
- add new molecule `IconWithBadge`
- document and test the component
- export in molecules index

## Testing
- `pnpm --filter ./frontend lint`
- `pnpm --filter ./frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68503bc7a788832bacc4b8db5bb7b46f