### PR TITLE
feat(stats): add StatWithIcon molecule

### DIFF
--- a/frontend/src/components/molecules/StatWithIcon.docs.mdx
+++ b/frontend/src/components/molecules/StatWithIcon.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './StatWithIcon.stories';
+import { StatWithIcon } from './StatWithIcon';
+
+<Meta of={Stories} />
+
+# StatWithIcon
+
+Widget para mostrar un KPI con un ícono representativo.
+
+<Story id="molecules-statwithicon--default" />
+
+<ArgsTable of={StatWithIcon} story="Default" />

--- a/frontend/src/components/molecules/StatWithIcon.stories.tsx
+++ b/frontend/src/components/molecules/StatWithIcon.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { StatWithIcon } from './StatWithIcon';
+
+const meta: Meta<typeof StatWithIcon> = {
+  title: 'Molecules/StatWithIcon',
+  component: StatWithIcon,
+  args: {
+    name: 'favorite',
+    value: '1,256',
+    label: 'Ventas hoy',
+    orientation: 'horizontal',
+  },
+  argTypes: {
+    name: {
+      control: 'select',
+      options: ['search', 'user', 'settings', 'menu', 'close', 'delete', 'favorite'],
+    },
+    icon: { control: false },
+    orientation: { control: 'radio', options: ['horizontal', 'vertical'] },
+    trend: { control: 'radio', options: ['up', 'down'] },
+    color: {
+      control: 'select',
+      options: [
+        'inherit',
+        'primary',
+        'secondary',
+        'action',
+        'disabled',
+        'error',
+        'info',
+        'success',
+        'warning',
+      ],
+    },
+    size: { control: 'select', options: ['inherit', 'small', 'medium', 'large'] },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof StatWithIcon>;
+
+export const Default: Story = {};
+export const Vertical: Story = { args: { orientation: 'vertical' } };
+export const TrendUp: Story = { args: { trend: 'up' } };
+export const TrendDown: Story = { args: { trend: 'down' } };

--- a/frontend/src/components/molecules/StatWithIcon.test.tsx
+++ b/frontend/src/components/molecules/StatWithIcon.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider } from '../../theme';
+import { StatWithIcon } from './StatWithIcon';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('StatWithIcon', () => {
+  it('renders value and label', () => {
+    renderWithTheme(<StatWithIcon value={100} label="Ventas" name="favorite" />);
+    expect(screen.getByText('100')).toBeInTheDocument();
+    expect(screen.getByText('Ventas')).toBeInTheDocument();
+  });
+
+  it('renders icon using name prop', () => {
+    const { container } = renderWithTheme(
+      <StatWithIcon value={20} label="Likes" name="favorite" />,
+    );
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+  });
+
+  it('applies vertical orientation', () => {
+    const { container } = renderWithTheme(
+      <StatWithIcon value={15} label="Clientes" name="user" orientation="vertical" />,
+    );
+    const root = container.firstChild as HTMLElement;
+    const style = window.getComputedStyle(root);
+    expect(style.flexDirection).toBe('column');
+  });
+
+  it('shows trend icon when specified', () => {
+    renderWithTheme(
+      <StatWithIcon value={50} label="Ingresos" name="search" trend="up" />,
+    );
+    expect(screen.getByTestId('trend-icon')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/molecules/StatWithIcon.tsx
+++ b/frontend/src/components/molecules/StatWithIcon.tsx
@@ -1,0 +1,70 @@
+import { Box, Typography } from '@mui/material';
+import ArrowDropUpIcon from '@mui/icons-material/ArrowDropUp';
+import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
+import { ReactElement } from 'react';
+import { Icon, IconProps, IconName } from '../atoms/Icon';
+
+export interface StatWithIconProps extends Omit<IconProps, 'icon' | 'name'> {
+  /** Nombre del ícono predefinido o componente personalizado */
+  icon?: ReactElement;
+  /** Nombre de ícono de la librería */
+  name?: IconName;
+  /** Valor numérico o texto destacado */
+  value: number | string;
+  /** Descripción de la métrica */
+  label: string;
+  /** Orientación del layout */
+  orientation?: 'horizontal' | 'vertical';
+  /** Tendencia de la métrica */
+  trend?: 'up' | 'down';
+}
+
+/**
+ * Widget compacto para mostrar una estadística junto a un ícono.
+ */
+export function StatWithIcon({
+  icon,
+  name,
+  value,
+  label,
+  orientation = 'horizontal',
+  trend,
+  color = 'inherit',
+  size = 'medium',
+  ...props
+}: StatWithIconProps) {
+  const TrendIcon =
+    trend === 'up' ? ArrowDropUpIcon : trend === 'down' ? ArrowDropDownIcon : null;
+  const trendColor =
+    trend === 'up' ? 'success' : trend === 'down' ? 'error' : undefined;
+
+  return (
+    <Box
+      display="flex"
+      alignItems="center"
+      flexDirection={orientation === 'vertical' ? 'column' : 'row'}
+      gap={1}
+    >
+      <Icon name={name} icon={icon} color={color} size={size} {...props} />
+      <Box
+        display="flex"
+        flexDirection="column"
+        alignItems={orientation === 'vertical' ? 'center' : 'flex-start'}
+      >
+        <Box display="flex" alignItems="center" gap={0.25}>
+          <Typography variant="h6" component="span">
+            {value}
+          </Typography>
+          {TrendIcon && (
+            <TrendIcon fontSize="small" color={trendColor} data-testid="trend-icon" />
+          )}
+        </Box>
+        <Typography variant="body2" color="text.secondary">
+          {label}
+        </Typography>
+      </Box>
+    </Box>
+  );
+}
+
+export default StatWithIcon;

--- a/frontend/src/components/molecules/index.ts
+++ b/frontend/src/components/molecules/index.ts
@@ -13,3 +13,4 @@ export { AvatarStatus } from './AvatarStatus';
 export { UserInfoDisplay } from './UserInfoDisplay';
 export { StatusBadgeDisplay } from './StatusBadgeDisplay';
 export { IconWithBadge } from './IconWithBadge';
+export { StatWithIcon } from './StatWithIcon';


### PR DESCRIPTION
## Summary
- create `StatWithIcon` molecule to display KPIs with an icon
- document new component and provide Storybook stories
- add tests
- export molecule from index

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6850571e4098832b9212ce8bfc153609