### PR TITLE
Add InfoTooltipIcon molecule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ docs(agents): aclara flujo de revisión para IA Codex
 | Requisito     | Norma                                                                                                                                                                           |
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Componentes   | Atomic Design (atoms → molecules → organisms → templates → pages)                                                                                                               |
-| Reutilización | Preferir añadir variantes o estados a átomos existentes en lugar de crear nuevos átomos |
+| Reutilización | Ajustar primero los átomos existentes (añadiendo variantes o estados) antes de crear uno nuevo |
 | Jerarquía     | Las páginas se construyen a partir de módulos; un módulo agrupa múltiples componentes, cada componente se forma con organismos, los organismos con moléculas y éstas con átomos |
 | Styling       | solo MUI v6 (`sx` / styled API); **nunca CSS suelto**                                                                                                                           |
 | Accesibilidad | score Lighthouse ≥ 90 (WCAG 2.2 AA)                                                                                                                                             |

--- a/frontend/src/components/atoms/Icon.stories.tsx
+++ b/frontend/src/components/atoms/Icon.stories.tsx
@@ -10,7 +10,16 @@ const meta: Meta<typeof Icon> = {
   argTypes: {
     name: {
       control: 'select',
-      options: ['search', 'user', 'settings', 'menu', 'close', 'delete', 'favorite'],
+      options: [
+        'search',
+        'user',
+        'settings',
+        'menu',
+        'close',
+        'delete',
+        'favorite',
+        'info',
+      ],
     },
     color: {
       control: 'select',
@@ -39,6 +48,7 @@ export const Gallery: Story = {
       <Icon name="close" />
       <Icon name="delete" color="error" />
       <Icon name="favorite" color="secondary" />
+      <Icon name="info" color="info" />
     </div>
   ),
 };

--- a/frontend/src/components/atoms/Icon.tsx
+++ b/frontend/src/components/atoms/Icon.tsx
@@ -7,6 +7,7 @@ import MenuIcon from '@mui/icons-material/Menu';
 import CloseIcon from '@mui/icons-material/Close';
 import DeleteIcon from '@mui/icons-material/Delete';
 import FavoriteIcon from '@mui/icons-material/Favorite';
+import InfoIcon from '@mui/icons-material/Info';
 
 const ICONS = {
   search: SearchIcon,
@@ -16,6 +17,7 @@ const ICONS = {
   close: CloseIcon,
   delete: DeleteIcon,
   favorite: FavoriteIcon,
+  info: InfoIcon,
 };
 
 export type IconName = keyof typeof ICONS;

--- a/frontend/src/components/molecules/InfoTooltipIcon.docs.mdx
+++ b/frontend/src/components/molecules/InfoTooltipIcon.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './InfoTooltipIcon.stories';
+import { InfoTooltipIcon } from './InfoTooltipIcon';
+
+<Meta of={Stories} />
+
+# InfoTooltipIcon
+
+Ícono informativo que muestra un tooltip al pasar el cursor o recibir foco.
+
+<Story id="molecules-infotooltipicon--default" />
+
+<ArgsTable of={InfoTooltipIcon} story="Default" />

--- a/frontend/src/components/molecules/InfoTooltipIcon.stories.tsx
+++ b/frontend/src/components/molecules/InfoTooltipIcon.stories.tsx
@@ -1,0 +1,62 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { InfoTooltipIcon } from './InfoTooltipIcon';
+
+const meta: Meta<typeof InfoTooltipIcon> = {
+  title: 'Molecules/InfoTooltipIcon',
+  component: InfoTooltipIcon,
+  args: {
+    text: 'Introduce el precio sin impuestos',
+    placement: 'right',
+    color: 'action',
+    size: 'medium',
+  },
+  argTypes: {
+    text: { control: 'text' },
+    placement: {
+      control: 'select',
+      options: ['bottom', 'top', 'right', 'left'],
+    },
+    color: {
+      control: 'select',
+      options: [
+        'inherit',
+        'primary',
+        'secondary',
+        'action',
+        'disabled',
+        'error',
+        'info',
+        'success',
+        'warning',
+      ],
+    },
+    size: { control: 'select', options: ['inherit', 'small', 'medium', 'large'] },
+    name: {
+      control: 'select',
+      options: [
+        'info',
+        'search',
+        'user',
+        'settings',
+        'menu',
+        'close',
+        'delete',
+        'favorite',
+      ],
+    },
+    icon: { control: false },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof InfoTooltipIcon>;
+
+export const Default: Story = {};
+
+export const LeftPlacement: Story = {
+  args: { placement: 'left' },
+};
+
+export const PrimaryColor: Story = {
+  args: { color: 'primary' },
+};

--- a/frontend/src/components/molecules/InfoTooltipIcon.test.tsx
+++ b/frontend/src/components/molecules/InfoTooltipIcon.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen, waitForElementToBeRemoved } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from '../../theme';
+import { InfoTooltipIcon } from './InfoTooltipIcon';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('InfoTooltipIcon', () => {
+  it('renders icon and tooltip on hover', async () => {
+    const user = userEvent.setup();
+    renderWithTheme(<InfoTooltipIcon text="Ayuda" />);
+    const icon = screen.getByLabelText('Ayuda');
+    await user.hover(icon);
+    expect(await screen.findByText('Ayuda')).toBeInTheDocument();
+    await user.unhover(icon);
+    await waitForElementToBeRemoved(() => screen.queryByText('Ayuda'));
+  });
+
+  it('shows tooltip on focus and hides on blur', async () => {
+    const user = userEvent.setup();
+    renderWithTheme(<InfoTooltipIcon text="Detalle" />);
+    const icon = screen.getByLabelText('Detalle');
+    await user.tab();
+    expect(icon).toHaveFocus();
+    expect(await screen.findByText('Detalle')).toBeInTheDocument();
+    await user.tab();
+    await waitForElementToBeRemoved(() => screen.queryByText('Detalle'));
+  });
+});

--- a/frontend/src/components/molecules/InfoTooltipIcon.tsx
+++ b/frontend/src/components/molecules/InfoTooltipIcon.tsx
@@ -1,0 +1,39 @@
+import { Icon, IconProps, Tooltip, TooltipProps } from '../atoms';
+
+export interface InfoTooltipIconProps
+  extends Pick<IconProps, 'size' | 'color' | 'icon' | 'name'> {
+  /** Contenido del tooltip que se mostrará al enfocar o pasar el cursor */
+  text: TooltipProps['title'];
+  /** Posición del tooltip respecto al ícono */
+  placement?: TooltipProps['placement'];
+}
+
+/**
+ * Ícono informativo que muestra un tooltip contextual al hover o focus.
+ */
+export function InfoTooltipIcon({
+  text,
+  placement = 'right',
+  size = 'medium',
+  color = 'action',
+  name = 'info',
+  icon,
+  ...props
+}: InfoTooltipIconProps) {
+  const ariaLabel = typeof text === 'string' ? text : undefined;
+  return (
+    <Tooltip title={text} placement={placement}>
+      <Icon
+        tabIndex={0}
+        name={name}
+        icon={icon}
+        size={size}
+        color={color}
+        aria-label={ariaLabel}
+        {...props}
+      />
+    </Tooltip>
+  );
+}
+
+export default InfoTooltipIcon;

--- a/frontend/src/components/molecules/index.ts
+++ b/frontend/src/components/molecules/index.ts
@@ -15,3 +15,4 @@ export { StatusBadgeDisplay } from './StatusBadgeDisplay';
 export { IconWithBadge } from './IconWithBadge';
 export { StatWithIcon } from './StatWithIcon';
 export { ProgressWithLabel } from './ProgressWithLabel';
+export { InfoTooltipIcon } from './InfoTooltipIcon';


### PR DESCRIPTION
## Summary
- update atom reuse guideline in `AGENTS.md`
- extend `Icon` with `info` icon support
- create `InfoTooltipIcon` molecule for contextual tooltips
- add stories, docs and tests
- export new molecule
- showcase new icon in `Icon` stories

## Testing
- `npx pnpm --dir frontend lint`
- `npx pnpm --dir frontend test`

------
https://chatgpt.com/codex/tasks/task_e_6850769999b0832b9f85a4c3c39c9726