### PR TITLE
feat(ui): add IconLabelButton molecule

### DIFF
--- a/frontend/src/components/molecules/IconLabelButton.docs.mdx
+++ b/frontend/src/components/molecules/IconLabelButton.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './IconLabelButton.stories';
+import { IconLabelButton } from './IconLabelButton';
+
+<Meta of={Stories} />
+
+# IconLabelButton
+
+Botón que combina un ícono y un texto en una sola acción.
+
+<Story id="molecules-iconlabelbutton--left-icon" />
+
+<ArgsTable of={IconLabelButton} story="LeftIcon" />

--- a/frontend/src/components/molecules/IconLabelButton.stories.tsx
+++ b/frontend/src/components/molecules/IconLabelButton.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import SaveIcon from '@mui/icons-material/Save';
+import SendIcon from '@mui/icons-material/Send';
+import SettingsIcon from '@mui/icons-material/Settings';
+import { IconLabelButton } from './IconLabelButton';
+
+const meta: Meta<typeof IconLabelButton> = {
+  title: 'Molecules/IconLabelButton',
+  component: IconLabelButton,
+  args: {
+    icon: <SaveIcon />,
+    label: 'Guardar',
+    iconPosition: 'left',
+    ariaLabel: 'accion',
+    disabled: false,
+  },
+  argTypes: {
+    icon: { control: false },
+    iconPosition: { control: 'radio', options: ['left', 'right'] },
+    label: { control: 'text' },
+    ariaLabel: { control: 'text' },
+    onClick: { action: 'clicked' },
+    disabled: { control: 'boolean' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof IconLabelButton>;
+
+export const LeftIcon: Story = {};
+
+export const RightIcon: Story = {
+  args: { iconPosition: 'right', icon: <SendIcon />, label: 'Enviar' },
+};
+
+export const IconOnly: Story = {
+  args: { label: undefined, icon: <SettingsIcon />, ariaLabel: 'configuración' },
+};
+
+export const Disabled: Story = {
+  args: { disabled: true },
+};

--- a/frontend/src/components/molecules/IconLabelButton.test.tsx
+++ b/frontend/src/components/molecules/IconLabelButton.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import SaveIcon from '@mui/icons-material/Save';
+import { ThemeProvider } from '../../theme';
+import { IconLabelButton } from './IconLabelButton';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('IconLabelButton', () => {
+  it('shows icon and text', () => {
+    const { container } = renderWithTheme(
+      <IconLabelButton icon={<SaveIcon />} label="Guardar" />,
+    );
+    expect(screen.getByText('Guardar')).toBeInTheDocument();
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('fires onClick when clicked', async () => {
+    const user = userEvent.setup();
+    const handleClick = jest.fn();
+    renderWithTheme(
+      <IconLabelButton icon={<SaveIcon />} label="Save" onClick={handleClick} />,
+    );
+    await user.click(screen.getByRole('button', { name: /save/i }));
+    expect(handleClick).toHaveBeenCalled();
+  });
+
+  it('does not fire onClick when disabled', () => {
+    const handleClick = jest.fn();
+    renderWithTheme(
+      <IconLabelButton
+        icon={<SaveIcon />}
+        label="Save"
+        onClick={handleClick}
+        disabled
+      />,
+    );
+    const btn = screen.getByRole('button', { name: /save/i });
+    btn.click();
+    expect(btn).toBeDisabled();
+    expect(handleClick).not.toHaveBeenCalled();
+  });
+
+  it('renders icon after text when iconPosition="right"', () => {
+    const { container } = renderWithTheme(
+      <IconLabelButton
+        icon={<SaveIcon data-testid="icon" />}
+        label="Enviar"
+        iconPosition="right"
+      />,
+    );
+    const btn = screen.getByRole('button', { name: /enviar/i });
+    const icon = screen.getByTestId('icon');
+    expect(btn.lastElementChild).toContainElement(icon);
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('renders only icon when no label', () => {
+    const { container } = renderWithTheme(
+      <IconLabelButton icon={<SaveIcon />} ariaLabel="guardar" />,
+    );
+    expect(screen.getByRole('button', { name: /guardar/i })).toBeInTheDocument();
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/molecules/IconLabelButton.tsx
+++ b/frontend/src/components/molecules/IconLabelButton.tsx
@@ -1,0 +1,41 @@
+import { ReactElement, ReactNode } from 'react';
+import { PrimaryButton, PrimaryButtonProps } from '../atoms/PrimaryButton';
+
+export interface IconLabelButtonProps
+  extends Omit<PrimaryButtonProps, 'startIcon' | 'endIcon' | 'children'> {
+  /** Icono que acompaña al texto */
+  icon: ReactElement;
+  /** Texto opcional del botón */
+  label?: ReactNode;
+  /** Posición del icono */
+  iconPosition?: 'left' | 'right';
+  /** Etiqueta accesible cuando no hay texto visible */
+  ariaLabel?: string;
+}
+
+/**
+ * Botón que combina ícono y texto para acciones claras.
+ */
+export function IconLabelButton({
+  icon,
+  label,
+  iconPosition = 'left',
+  ariaLabel,
+  ...props
+}: IconLabelButtonProps) {
+  const startIcon = iconPosition === 'left' ? icon : undefined;
+  const endIcon = iconPosition === 'right' ? icon : undefined;
+
+  return (
+    <PrimaryButton
+      startIcon={startIcon}
+      endIcon={endIcon}
+      aria-label={!label ? ariaLabel : undefined}
+      {...props}
+    >
+      {label}
+    </PrimaryButton>
+  );
+}
+
+export default IconLabelButton;

--- a/frontend/src/components/molecules/index.ts
+++ b/frontend/src/components/molecules/index.ts
@@ -16,3 +16,4 @@ export { IconWithBadge } from './IconWithBadge';
 export { StatWithIcon } from './StatWithIcon';
 export { ProgressWithLabel } from './ProgressWithLabel';
 export { InfoTooltipIcon } from './InfoTooltipIcon';
+export { IconLabelButton } from './IconLabelButton';


### PR DESCRIPTION
## Summary
- add IconLabelButton molecule
- document IconLabelButton
- storybook and tests for IconLabelButton

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685081179a4c832bae782388a9a20ade