### PR TITLE
feat(ui): add ProductListItem molecule

### DIFF
--- a/frontend/src/components/molecules/ProductListItem.docs.mdx
+++ b/frontend/src/components/molecules/ProductListItem.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './ProductListItem.stories';
+import { ProductListItem } from './ProductListItem';
+
+<Meta of={Stories} />
+
+# ProductListItem
+
+Molecula que muestra un producto en listados o resultados de búsqueda.
+
+<Story id="molecules-productlistitem--available" />
+
+<ArgsTable of={ProductListItem} story="Available" />

--- a/frontend/src/components/molecules/ProductListItem.stories.tsx
+++ b/frontend/src/components/molecules/ProductListItem.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ProductListItem } from './ProductListItem';
+
+const meta: Meta<typeof ProductListItem> = {
+  title: 'Molecules/ProductListItem',
+  component: ProductListItem,
+  args: {
+    name: 'Camisa Polo',
+    price: 49.99,
+    src: 'https://placehold.co/40',
+    status: 'available',
+    size: 'medium',
+  },
+  argTypes: {
+    status: { control: 'select', options: ['available', 'out_of_stock', 'promotion'] },
+    size: { control: 'select', options: ['small', 'medium', 'large'] },
+    src: { control: 'text' },
+    name: { control: 'text' },
+    price: { control: 'number' },
+    selected: { control: 'boolean' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof ProductListItem>;
+
+export const Available: Story = {};
+
+export const OutOfStock: Story = {
+  args: { status: 'out_of_stock' },
+};
+
+export const Promotion: Story = {
+  args: { status: 'promotion' },
+};
+
+export const Selected: Story = {
+  args: { selected: true },
+};
+
+export const WithoutImage: Story = {
+  args: { src: undefined },
+};

--- a/frontend/src/components/molecules/ProductListItem.test.tsx
+++ b/frontend/src/components/molecules/ProductListItem.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from '../../theme';
+import { ProductListItem } from './ProductListItem';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('ProductListItem', () => {
+  it('renders image, name, price and status', () => {
+    renderWithTheme(
+      <ProductListItem
+        name="Camisa Polo"
+        price={49.99}
+        status="available"
+        src="polo.png"
+      />,
+    );
+    expect(screen.getByRole('img', { name: /camisa polo/i })).toHaveAttribute(
+      'src',
+      'polo.png',
+    );
+    expect(screen.getByText('Camisa Polo')).toBeInTheDocument();
+    expect(screen.getByText('$49.99')).toBeInTheDocument();
+    expect(screen.getByText('Disponible')).toBeInTheDocument();
+  });
+
+  it('shows initials when image missing', () => {
+    renderWithTheme(
+      <ProductListItem name="Zapatos XY" price={89.5} status="out_of_stock" />,
+    );
+    expect(screen.getByText('ZX')).toBeInTheDocument();
+  });
+
+  it('formats price with currency', () => {
+    renderWithTheme(
+      <ProductListItem
+        name="Pantal\u00F3n"
+        price={1000}
+        currency="EUR"
+        status="promotion"
+      />,
+    );
+    const formatted = new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'EUR',
+    }).format(1000);
+    expect(screen.getByText(formatted)).toBeInTheDocument();
+  });
+
+  it('uses correct color for out of stock status', () => {
+    const { container } = renderWithTheme(
+      <ProductListItem name="Test" price={1} status="out_of_stock" />,
+    );
+    const chip = container.querySelector('.MuiChip-root') as HTMLElement;
+    expect(chip).toHaveClass('MuiChip-colorError');
+  });
+
+  it('fires onClick when item is clicked', async () => {
+    const user = userEvent.setup();
+    const handleClick = jest.fn();
+    renderWithTheme(<ProductListItem name="Botas" price={50} onClick={handleClick} />);
+    await user.click(screen.getByText('Botas'));
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/molecules/ProductListItem.tsx
+++ b/frontend/src/components/molecules/ProductListItem.tsx
@@ -1,0 +1,92 @@
+import { Box, Typography } from '@mui/material';
+import { Avatar, AvatarProps, Chip } from '../atoms';
+
+export interface ProductListItemProps extends Omit<AvatarProps, 'children'> {
+  /** Nombre del producto */
+  name: string;
+  /** Precio num\u00E9rico */
+  price: number;
+  /** Estado del producto */
+  status?: 'available' | 'out_of_stock' | 'promotion';
+  /** C\u00F3digo de moneda ISO 4217 */
+  currency?: string;
+  /** Imagen del producto */
+  src?: string;
+  /** Resalta el fondo cuando est\u00E1 seleccionado */
+  selected?: boolean;
+  /** Manejador de click opcional */
+  onClick?: () => void;
+}
+
+const STATUS_LABELS = {
+  available: 'Disponible',
+  out_of_stock: 'Sin stock',
+  promotion: 'En oferta',
+} as const;
+
+const STATUS_COLORS = {
+  available: 'success',
+  out_of_stock: 'error',
+  promotion: 'warning',
+} as const;
+
+/**
+ * Elemento compacto para listados de productos.
+ */
+export function ProductListItem({
+  name,
+  price,
+  status = 'available',
+  currency = 'USD',
+  src,
+  size = 'medium',
+  selected = false,
+  onClick,
+  ...avatarProps
+}: ProductListItemProps) {
+  const formattedPrice = new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency,
+  }).format(price);
+
+  const initials =
+    !src && name
+      ? name
+          .split(/\s+/)
+          .map((w) => w[0])
+          .slice(0, 2)
+          .join('')
+          .toUpperCase()
+      : undefined;
+
+  return (
+    <Box
+      display="flex"
+      alignItems="center"
+      gap={1}
+      px={1}
+      py={0.5}
+      onClick={onClick}
+      sx={{
+        cursor: onClick ? 'pointer' : 'default',
+        bgcolor: selected ? 'action.selected' : undefined,
+        '&:hover': onClick ? { bgcolor: 'action.hover' } : undefined,
+      }}
+    >
+      <Avatar variant="rounded" alt={name} src={src} size={size} {...avatarProps}>
+        {initials}
+      </Avatar>
+      <Box flexGrow={1} minWidth={0}>
+        <Typography variant="body1" noWrap>
+          {name}
+        </Typography>
+        <Typography variant="body2" color="text.secondary" noWrap>
+          {formattedPrice}
+        </Typography>
+      </Box>
+      <Chip label={STATUS_LABELS[status]} color={STATUS_COLORS[status]} size="small" />
+    </Box>
+  );
+}
+
+export default ProductListItem;

--- a/frontend/src/components/molecules/index.ts
+++ b/frontend/src/components/molecules/index.ts
@@ -17,3 +17,4 @@ export { StatWithIcon } from './StatWithIcon';
 export { ProgressWithLabel } from './ProgressWithLabel';
 export { InfoTooltipIcon } from './InfoTooltipIcon';
 export { IconLabelButton } from './IconLabelButton';
+export { ProductListItem } from './ProductListItem';


### PR DESCRIPTION
## Summary
- add ProductListItem molecule for product listings
- include stories, docs and tests
- export molecule from index

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685085415198832bb17209ae1de28056