### PR TITLE
feat(ui): add OrderListItem molecule

### DIFF
--- a/frontend/src/components/molecules/OrderListItem.docs.mdx
+++ b/frontend/src/components/molecules/OrderListItem.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './OrderListItem.stories';
+import { OrderListItem } from './OrderListItem';
+
+<Meta of={Stories} />
+
+# OrderListItem
+
+Molecula que muestra un pedido en listados o res\u00FAmenes.
+
+<Story id="molecules-orderlistitem--pending" />
+
+<ArgsTable of={OrderListItem} story="Pending" />

--- a/frontend/src/components/molecules/OrderListItem.stories.tsx
+++ b/frontend/src/components/molecules/OrderListItem.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { OrderListItem } from './OrderListItem';
+
+const meta: Meta<typeof OrderListItem> = {
+  title: 'Molecules/OrderListItem',
+  component: OrderListItem,
+  args: {
+    orderNumber: 1001,
+    date: '2025-06-12',
+    customer: 'Ana G\u00F3mez',
+    total: 150,
+    status: 'pending',
+    variant: 'full',
+    iconName: 'info',
+  },
+  argTypes: {
+    status: {
+      control: 'select',
+      options: ['pending', 'shipped', 'delivered', 'cancelled'],
+    },
+    variant: { control: 'radio', options: ['full', 'compact'] },
+    iconName: {
+      control: 'select',
+      options: [
+        undefined,
+        'search',
+        'user',
+        'settings',
+        'menu',
+        'close',
+        'delete',
+        'favorite',
+        'info',
+      ],
+    },
+    onClick: { action: 'clicked' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof OrderListItem>;
+
+export const Pending: Story = {};
+
+export const Shipped: Story = {
+  args: { status: 'shipped' },
+};
+
+export const Delivered: Story = {
+  args: { status: 'delivered' },
+};
+
+export const Cancelled: Story = {
+  args: { status: 'cancelled' },
+};
+
+export const Compact: Story = {
+  args: { variant: 'compact' },
+};

--- a/frontend/src/components/molecules/OrderListItem.test.tsx
+++ b/frontend/src/components/molecules/OrderListItem.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from '../../theme';
+import { OrderListItem } from './OrderListItem';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('OrderListItem', () => {
+  it('renders number, date, customer, total and status', () => {
+    renderWithTheme(
+      <OrderListItem
+        orderNumber={1001}
+        date="2025-06-12"
+        customer="Ana"
+        total={50}
+        status="pending"
+      />,
+    );
+    expect(screen.getByText('#1001')).toBeInTheDocument();
+    expect(screen.getByText('12/06/2025')).toBeInTheDocument();
+    expect(screen.getByText('Ana')).toBeInTheDocument();
+    expect(screen.getByText('$50.00')).toBeInTheDocument();
+    expect(screen.getByText('Pendiente')).toBeInTheDocument();
+  });
+
+  it('uses correct color for delivered status', () => {
+    const { container } = renderWithTheme(
+      <OrderListItem orderNumber={1} date="2025-06-12" status="delivered" />,
+    );
+    const chip = container.querySelector('.MuiChip-root') as HTMLElement;
+    expect(chip).toHaveClass('MuiChip-colorSuccess');
+  });
+
+  it('hides customer and total in compact variant', () => {
+    renderWithTheme(
+      <OrderListItem
+        orderNumber={1}
+        date="2025-06-12"
+        customer="Ana"
+        total={10}
+        variant="compact"
+      />,
+    );
+    expect(screen.queryByText('Ana')).toBeNull();
+    expect(screen.queryByText('$10.00')).toBeNull();
+  });
+
+  it('fires onClick when item clicked', async () => {
+    const user = userEvent.setup();
+    const handle = jest.fn();
+    renderWithTheme(
+      <OrderListItem orderNumber={1} date="2025-06-12" onClick={handle} />,
+    );
+    await user.click(screen.getByText('#1'));
+    expect(handle).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/molecules/OrderListItem.tsx
+++ b/frontend/src/components/molecules/OrderListItem.tsx
@@ -1,0 +1,106 @@
+import { Box, Typography } from '@mui/material';
+import dayjs from 'dayjs';
+import { Chip, Icon } from '../atoms';
+import type { IconName } from '../atoms/Icon';
+
+export interface OrderListItemProps {
+  /** N\u00FAmero identificador del pedido */
+  orderNumber: string | number;
+  /** Fecha del pedido */
+  date: string | Date;
+  /** Nombre del cliente a mostrar */
+  customer?: string;
+  /** Total del pedido */
+  total?: number;
+  /** C\u00F3digo de moneda ISO 4217 para el total */
+  currency?: string;
+  /** Estado actual del pedido */
+  status?: 'pending' | 'shipped' | 'delivered' | 'cancelled';
+  /** Variante de presentaci\u00F3n */
+  variant?: 'full' | 'compact';
+  /** Resaltar por ser reciente */
+  recent?: boolean;
+  /** Icono opcional */
+  iconName?: IconName;
+  /** Marcar fondo cuando est\u00E1 seleccionado */
+  selected?: boolean;
+  /** Manejador de clic */
+  onClick?: () => void;
+}
+
+const STATUS_LABELS = {
+  pending: 'Pendiente',
+  shipped: 'Enviado',
+  delivered: 'Entregado',
+  cancelled: 'Cancelado',
+} as const;
+
+const STATUS_COLORS = {
+  pending: 'warning',
+  shipped: 'info',
+  delivered: 'success',
+  cancelled: 'error',
+} as const;
+
+/**
+ * \u00CDtem compacto para listados de pedidos.
+ */
+export function OrderListItem({
+  orderNumber,
+  date,
+  customer,
+  total,
+  currency = 'USD',
+  status = 'pending',
+  variant = 'full',
+  recent = false,
+  iconName,
+  selected = false,
+  onClick,
+}: OrderListItemProps) {
+  const formattedDate = dayjs(date).format('DD/MM/YYYY');
+  const formattedTotal =
+    total !== undefined
+      ? new Intl.NumberFormat('en-US', { style: 'currency', currency }).format(total)
+      : undefined;
+
+  return (
+    <Box
+      display="flex"
+      alignItems="center"
+      gap={1}
+      px={1}
+      py={0.5}
+      onClick={onClick}
+      sx={{
+        cursor: onClick ? 'pointer' : 'default',
+        bgcolor: selected || recent ? 'action.selected' : undefined,
+        '&:hover': onClick ? { bgcolor: 'action.hover' } : undefined,
+      }}
+    >
+      {iconName && <Icon name={iconName} size="small" />}
+      <Typography variant="body1" noWrap>{`#${orderNumber}`}</Typography>
+      {variant === 'full' && (
+        <>
+          <Typography variant="body2" color="text.secondary" noWrap>
+            {formattedDate}
+          </Typography>
+          {customer && (
+            <Typography variant="body2" color="text.secondary" noWrap>
+              {customer}
+            </Typography>
+          )}
+          {formattedTotal && (
+            <Typography variant="body2" color="text.secondary" noWrap>
+              {formattedTotal}
+            </Typography>
+          )}
+        </>
+      )}
+      <Box flexGrow={1} />
+      <Chip label={STATUS_LABELS[status]} color={STATUS_COLORS[status]} size="small" />
+    </Box>
+  );
+}
+
+export default OrderListItem;

--- a/frontend/src/components/molecules/index.ts
+++ b/frontend/src/components/molecules/index.ts
@@ -18,3 +18,4 @@ export { ProgressWithLabel } from './ProgressWithLabel';
 export { InfoTooltipIcon } from './InfoTooltipIcon';
 export { IconLabelButton } from './IconLabelButton';
 export { ProductListItem } from './ProductListItem';
+export { OrderListItem } from './OrderListItem';


### PR DESCRIPTION
## Summary
- add `OrderListItem` molecule component
- document and create stories for `OrderListItem`
- add unit tests
- export component from molecules index

## Testing
- `pnpm test`
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_685098cb6018832b8faa2ef5fa103676