### PR TITLE
Add CustomerListItem molecule

### DIFF
--- a/frontend/src/components/molecules/CustomerListItem.docs.mdx
+++ b/frontend/src/components/molecules/CustomerListItem.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './CustomerListItem.stories';
+import { CustomerListItem } from './CustomerListItem';
+
+<Meta of={Stories} />
+
+# CustomerListItem
+
+Molecula que muestra informaci\u00F3n resumida de un cliente en listados.
+
+<Story id="molecules-customerlistitem--with-avatar" />
+
+<ArgsTable of={CustomerListItem} story="WithAvatar" />

--- a/frontend/src/components/molecules/CustomerListItem.stories.tsx
+++ b/frontend/src/components/molecules/CustomerListItem.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { CustomerListItem } from './CustomerListItem';
+
+const meta: Meta<typeof CustomerListItem> = {
+  title: 'Molecules/CustomerListItem',
+  component: CustomerListItem,
+  args: {
+    name: 'Ana G\u00F3mez',
+    typeLabel: 'VIP',
+    typeColor: 'warning',
+    status: 'active',
+    src: 'https://i.pravatar.cc/40',
+    size: 'medium',
+  },
+  argTypes: {
+    status: { control: 'select', options: ['active', 'inactive'] },
+    typeColor: {
+      control: 'select',
+      options: [
+        'default',
+        'primary',
+        'secondary',
+        'error',
+        'info',
+        'success',
+        'warning',
+      ],
+    },
+    size: { control: 'select', options: ['small', 'medium', 'large'] },
+    src: { control: 'text' },
+    name: { control: 'text' },
+    typeLabel: { control: 'text' },
+    secondaryInfo: { control: 'text' },
+    selected: { control: 'boolean' },
+    onClick: { action: 'clicked' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof CustomerListItem>;
+
+export const WithAvatar: Story = {};
+
+export const WithoutAvatar: Story = {
+  args: { src: undefined, typeLabel: 'Nuevo', typeColor: 'success' },
+};
+
+export const Inactive: Story = {
+  args: { status: 'inactive' },
+};
+
+export const WithSecondary: Story = {
+  args: { secondaryInfo: 'ana@example.com' },
+};

--- a/frontend/src/components/molecules/CustomerListItem.test.tsx
+++ b/frontend/src/components/molecules/CustomerListItem.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider } from '../../theme';
+import { CustomerListItem } from './CustomerListItem';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('CustomerListItem', () => {
+  it('renders avatar image, name and chip', () => {
+    renderWithTheme(
+      <CustomerListItem
+        name="Ana Gomez"
+        src="avatar.png"
+        typeLabel="VIP"
+        typeColor="warning"
+      />,
+    );
+    expect(screen.getByRole('img', { name: /ana gomez/i })).toHaveAttribute(
+      'src',
+      'avatar.png',
+    );
+    expect(screen.getByText('Ana Gomez')).toBeInTheDocument();
+    expect(screen.getByText('VIP')).toBeInTheDocument();
+  });
+
+  it('shows initials when image missing', () => {
+    renderWithTheme(<CustomerListItem name="Juan Perez" />);
+    expect(screen.getByText('JP')).toBeInTheDocument();
+  });
+
+  it('applies inactive styles', () => {
+    const { container } = renderWithTheme(
+      <CustomerListItem name="Ana" status="inactive" />,
+    );
+    const badge = container.querySelector('.MuiBadge-badge') as HTMLElement;
+    expect(badge).not.toHaveClass('MuiBadge-colorSuccess');
+    const name = screen.getByText('Ana');
+    expect(name).toHaveStyle({ color: 'rgba(0, 0, 0, 0.38)' });
+  });
+});

--- a/frontend/src/components/molecules/CustomerListItem.tsx
+++ b/frontend/src/components/molecules/CustomerListItem.tsx
@@ -1,0 +1,105 @@
+import { Box, Typography } from '@mui/material';
+import { Avatar, AvatarProps, Badge } from '../atoms';
+import { Chip, ChipProps } from '../atoms/Chip';
+
+export interface CustomerListItemProps extends Omit<AvatarProps, 'children'> {
+  /** Nombre completo del cliente */
+  name: string;
+  /** Muestra un punto verde o gris seg\u00FAn si est\u00E1 activo */
+  status?: 'active' | 'inactive';
+  /** Etiqueta que clasifica al cliente (VIP, Nuevo, etc.) */
+  typeLabel?: string;
+  /** Color de la etiqueta */
+  typeColor?: ChipProps['color'];
+  /** Informaci\u00F3n secundaria como email o tel\u00E9fono */
+  secondaryInfo?: string;
+  /** Imagen del cliente */
+  src?: string;
+  /** Resalta el fondo si est\u00E1 seleccionado */
+  selected?: boolean;
+  /** Manejador de clic opcional */
+  onClick?: () => void;
+}
+
+const STATUS_COLOR_MAP = {
+  active: 'success',
+  inactive: 'default',
+} as const;
+
+const AVATAR_SIZE_MAP = {
+  small: 32,
+  medium: 40,
+  large: 64,
+} as const;
+
+/**\n * \u00CDtem compacto para listados de clientes.\n */
+export function CustomerListItem({
+  name,
+  status = 'active',
+  typeLabel,
+  typeColor = 'default',
+  secondaryInfo,
+  size = 'medium',
+  src,
+  selected = false,
+  onClick,
+  ...avatarProps
+}: CustomerListItemProps) {
+  const initials =
+    !src && name
+      ? name
+          .split(/\s+/)
+          .map((w) => w[0])
+          .slice(0, 2)
+          .join('')
+          .toUpperCase()
+      : undefined;
+
+  const dotSize = Math.round((AVATAR_SIZE_MAP[size] ?? 40) * 0.35);
+
+  return (
+    <Box
+      display="flex"
+      alignItems="center"
+      gap={1}
+      px={1}
+      py={0.5}
+      onClick={onClick}
+      sx={{
+        cursor: onClick ? 'pointer' : 'default',
+        bgcolor: selected ? 'action.selected' : undefined,
+        '&:hover': onClick ? { bgcolor: 'action.hover' } : undefined,
+      }}
+    >
+      <Badge
+        content={0}
+        variant="dot"
+        overlap="circular"
+        color={STATUS_COLOR_MAP[status]}
+        showZero
+        slotProps={{ badge: { sx: { height: dotSize, minWidth: dotSize } } }}
+      >
+        <Avatar alt={name} src={src} size={size} {...avatarProps}>
+          {initials}
+        </Avatar>
+      </Badge>
+      <Box flexGrow={1} minWidth={0}>
+        <Typography
+          variant="body1"
+          noWrap
+          sx={{ color: status === 'inactive' ? 'text.disabled' : undefined }}
+        >
+          {name}
+        </Typography>
+        {secondaryInfo && (
+          <Typography variant="body2" color="text.secondary" noWrap>
+            {secondaryInfo}
+          </Typography>
+        )}
+      </Box>
+      {typeLabel && <Chip label={typeLabel} color={typeColor} size="small" />}
+    </Box>
+  );
+}
+
+export default CustomerListItem;

--- a/frontend/src/components/molecules/index.ts
+++ b/frontend/src/components/molecules/index.ts
@@ -19,3 +19,4 @@ export { InfoTooltipIcon } from './InfoTooltipIcon';
 export { IconLabelButton } from './IconLabelButton';
 export { ProductListItem } from './ProductListItem';
 export { OrderListItem } from './OrderListItem';
+export { CustomerListItem } from './CustomerListItem';


### PR DESCRIPTION
## Summary
- add `CustomerListItem` molecule with avatar, badge, and label
- document the component in Storybook
- provide stories and tests
- export from molecules index

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850e73b00e8832b998b007a172555e2