### PR TITLE
feat: add InventoryStatusItem molecule

### DIFF
--- a/frontend/src/components/molecules/InventoryStatusItem.docs.mdx
+++ b/frontend/src/components/molecules/InventoryStatusItem.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './InventoryStatusItem.stories';
+import { InventoryStatusItem } from './InventoryStatusItem';
+
+<Meta of={Stories} />
+
+# InventoryStatusItem
+
+Molecula que muestra el estado de inventario de un producto.
+
+<Story id="molecules-inventorystatusitem--in-stock" />
+
+<ArgsTable of={InventoryStatusItem} story="InStock" />

--- a/frontend/src/components/molecules/InventoryStatusItem.stories.tsx
+++ b/frontend/src/components/molecules/InventoryStatusItem.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { InventoryStatusItem } from './InventoryStatusItem';
+
+const meta: Meta<typeof InventoryStatusItem> = {
+  title: 'Molecules/InventoryStatusItem',
+  component: InventoryStatusItem,
+  args: {
+    name: 'Polo Azul',
+    stock: 30,
+    lowStockThreshold: 5,
+    editable: false,
+    iconName: 'info',
+  },
+  argTypes: {
+    lowStockThreshold: { control: 'number' },
+    editable: { control: 'boolean' },
+    stock: { control: 'number' },
+    iconName: {
+      control: 'select',
+      options: [
+        undefined,
+        'search',
+        'user',
+        'settings',
+        'menu',
+        'close',
+        'delete',
+        'favorite',
+        'info',
+      ],
+    },
+    onStockChange: { action: 'changed' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof InventoryStatusItem>;
+
+export const InStock: Story = {};
+
+export const LowStock: Story = {
+  args: { stock: 4 },
+};
+
+export const OutOfStock: Story = {
+  args: { stock: 0 },
+};
+
+export const Editable: Story = {
+  args: { editable: true },
+};
+
+export const WithoutIcon: Story = {
+  args: { iconName: undefined },
+};

--- a/frontend/src/components/molecules/InventoryStatusItem.test.tsx
+++ b/frontend/src/components/molecules/InventoryStatusItem.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from '../../theme';
+import { InventoryStatusItem } from './InventoryStatusItem';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('InventoryStatusItem', () => {
+  it('shows name and stock', () => {
+    renderWithTheme(<InventoryStatusItem name="Polo Azul" stock={10} />);
+    expect(screen.getByText('Polo Azul')).toBeInTheDocument();
+    expect(screen.getByText('10')).toBeInTheDocument();
+  });
+
+  it('displays out of stock status', () => {
+    const { container } = renderWithTheme(
+      <InventoryStatusItem name="Chaqueta" stock={0} />,
+    );
+    expect(screen.getByText('Sin stock')).toBeInTheDocument();
+    const chip = container.querySelector('.MuiChip-root') as HTMLElement;
+    expect(chip).toHaveClass('MuiChip-colorError');
+  });
+
+  it('displays low stock when below threshold', () => {
+    const { container } = renderWithTheme(
+      <InventoryStatusItem name="Jeans" stock={3} lowStockThreshold={5} />,
+    );
+    expect(screen.getByText('Stock bajo')).toBeInTheDocument();
+    const chip = container.querySelector('.MuiChip-root') as HTMLElement;
+    expect(chip).toHaveClass('MuiChip-colorWarning');
+  });
+
+  it('displays in stock when above threshold', () => {
+    const { container } = renderWithTheme(
+      <InventoryStatusItem name="Camisa" stock={8} lowStockThreshold={5} />,
+    );
+    expect(screen.getByText('En stock')).toBeInTheDocument();
+    const chip = container.querySelector('.MuiChip-root') as HTMLElement;
+    expect(chip).toHaveClass('MuiChip-colorSuccess');
+  });
+
+  it('calls onStockChange when editable', async () => {
+    const user = userEvent.setup();
+    const handleChange = jest.fn();
+    renderWithTheme(
+      <InventoryStatusItem
+        name="Zapatos"
+        stock={2}
+        editable
+        onStockChange={handleChange}
+      />,
+    );
+    const input = screen.getByRole('spinbutton');
+    await user.type(input, '5');
+    expect(handleChange).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/molecules/InventoryStatusItem.tsx
+++ b/frontend/src/components/molecules/InventoryStatusItem.tsx
@@ -1,0 +1,81 @@
+import { Box, Typography } from '@mui/material';
+import { useId } from 'react';
+import { NumberInput, Chip, Icon } from '../atoms';
+import type { IconName } from '../atoms/Icon';
+
+export interface InventoryStatusItemProps {
+  /** Nombre del producto */
+  name: string;
+  /** Cantidad disponible en inventario */
+  stock: number;
+  /** Umbral para considerar stock bajo */
+  lowStockThreshold?: number;
+  /** Mostrar campo editable en lugar de texto */
+  editable?: boolean;
+  /** Icono decorativo opcional */
+  iconName?: IconName;
+  /** Manejador cuando cambia la cantidad (modo editable) */
+  onStockChange?: (value: number) => void;
+}
+
+const STATUS_LABELS = {
+  in_stock: 'En stock',
+  low_stock: 'Stock bajo',
+  out_of_stock: 'Sin stock',
+} as const;
+
+const STATUS_COLORS = {
+  in_stock: 'success',
+  low_stock: 'warning',
+  out_of_stock: 'error',
+} as const;
+
+function getStatus(stock: number, threshold: number) {
+  if (stock <= 0) return 'out_of_stock';
+  if (stock < threshold) return 'low_stock';
+  return 'in_stock';
+}
+
+/**
+ * Muestra la cantidad de inventario y su estado con un chip de colores.
+ */
+export function InventoryStatusItem({
+  name,
+  stock,
+  lowStockThreshold = 5,
+  editable = false,
+  iconName,
+  onStockChange,
+}: InventoryStatusItemProps) {
+  const status = getStatus(stock, lowStockThreshold);
+  const chipLabel = STATUS_LABELS[status];
+  const chipColor = STATUS_COLORS[status];
+  const inputId = useId();
+
+  return (
+    <Box display="flex" alignItems="center" gap={1} px={1} py={0.5}>
+      {iconName && <Icon name={iconName} size="small" />}
+      <Typography variant="body1" noWrap sx={{ flexGrow: 1 }}>
+        {name}
+      </Typography>
+      {editable ? (
+        <NumberInput
+          id={inputId}
+          aria-label={`stock de ${name}`}
+          value={stock}
+          onChange={(_, value) => {
+            if (value !== '') onStockChange?.(value);
+          }}
+          size="small"
+        />
+      ) : (
+        <Typography variant="body2" sx={{ minWidth: 24 }}>
+          {stock}
+        </Typography>
+      )}
+      <Chip label={chipLabel} color={chipColor} size="small" />
+    </Box>
+  );
+}
+
+export default InventoryStatusItem;

--- a/frontend/src/components/molecules/index.ts
+++ b/frontend/src/components/molecules/index.ts
@@ -20,3 +20,4 @@ export { IconLabelButton } from './IconLabelButton';
 export { ProductListItem } from './ProductListItem';
 export { OrderListItem } from './OrderListItem';
 export { CustomerListItem } from './CustomerListItem';
+export { InventoryStatusItem } from './InventoryStatusItem';


### PR DESCRIPTION
## Summary
- add `InventoryStatusItem` molecule to display stock level and status
- document and showcase the component in Storybook
- cover new molecule with unit tests
- export molecule from component index

## Testing
- `pnpm --filter ./frontend lint`
- `pnpm --filter ./frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68515774a3d8832ba01ec1d8414af0cc