### PR TITLE
feat(frontend): add PromotionBadge molecule

### DIFF
--- a/frontend/src/components/atoms/ChipTag.docs.mdx
+++ b/frontend/src/components/atoms/ChipTag.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './ChipTag.stories';
+import { ChipTag } from './ChipTag';
+
+<Meta of={Stories} />
+
+# ChipTag
+
+Contenedor visual compacto para resaltar promociones o etiquetas breves.
+
+<Story id="atoms-chiptag--basic" />
+
+<ArgsTable of={ChipTag} story="Basic" />

--- a/frontend/src/components/atoms/ChipTag.stories.tsx
+++ b/frontend/src/components/atoms/ChipTag.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ChipTag } from './ChipTag';
+import PercentIcon from '@mui/icons-material/Percent';
+
+const meta: Meta<typeof ChipTag> = {
+  title: 'Atoms/ChipTag',
+  component: ChipTag,
+  args: {
+    label: '20% OFF',
+    color: 'primary',
+    icon: <PercentIcon fontSize="small" />,
+  },
+  argTypes: {
+    color: {
+      control: 'select',
+      options: [
+        'default',
+        'primary',
+        'secondary',
+        'error',
+        'info',
+        'success',
+        'warning',
+      ],
+    },
+    onClick: { action: 'clicked' },
+    icon: { control: false },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof ChipTag>;
+
+export const Basic: Story = {};
+
+export const WithoutIcon: Story = {
+  args: { icon: undefined, label: 'SALE' },
+};

--- a/frontend/src/components/atoms/ChipTag.test.tsx
+++ b/frontend/src/components/atoms/ChipTag.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react';
+import PercentIcon from '@mui/icons-material/Percent';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from '../../theme';
+import { ChipTag } from './ChipTag';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('ChipTag', () => {
+  it('renders label text', () => {
+    renderWithTheme(<ChipTag label="Promo" />);
+    expect(screen.getByText('Promo')).toBeInTheDocument();
+  });
+
+  it('shows icon when provided', () => {
+    const { container } = renderWithTheme(
+      <ChipTag label="Promo" icon={<PercentIcon />} />,
+    );
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('applies color class', () => {
+    const { container } = renderWithTheme(<ChipTag label="Promo" color="primary" />);
+    const chip = container.querySelector('.MuiChip-root') as HTMLElement;
+    expect(chip).toHaveClass('MuiChip-colorPrimary');
+  });
+
+  it('handles click events', async () => {
+    const user = userEvent.setup();
+    const handleClick = jest.fn();
+    renderWithTheme(<ChipTag label="Click" onClick={handleClick} />);
+    await user.click(screen.getByRole('button', { name: /click/i }));
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/atoms/ChipTag.tsx
+++ b/frontend/src/components/atoms/ChipTag.tsx
@@ -1,0 +1,22 @@
+import { Chip, ChipProps } from './Chip';
+import { ReactElement } from 'react';
+
+export interface ChipTagProps extends ChipProps {
+  /** Ícono opcional que se muestra al inicio. */
+  icon?: ReactElement;
+}
+
+/**
+ * Pequeño contenedor visual para etiquetas de promoción.
+ */
+export function ChipTag({
+  icon,
+  size = 'small',
+  variant = 'filled',
+  color = 'default',
+  ...props
+}: ChipTagProps) {
+  return <Chip icon={icon} size={size} variant={variant} color={color} {...props} />;
+}
+
+export default ChipTag;

--- a/frontend/src/components/atoms/Icon.tsx
+++ b/frontend/src/components/atoms/Icon.tsx
@@ -8,6 +8,8 @@ import CloseIcon from '@mui/icons-material/Close';
 import DeleteIcon from '@mui/icons-material/Delete';
 import FavoriteIcon from '@mui/icons-material/Favorite';
 import InfoIcon from '@mui/icons-material/Info';
+import LocalOfferIcon from '@mui/icons-material/LocalOffer';
+import PercentIcon from '@mui/icons-material/Percent';
 
 const ICONS = {
   search: SearchIcon,
@@ -18,6 +20,8 @@ const ICONS = {
   delete: DeleteIcon,
   favorite: FavoriteIcon,
   info: InfoIcon,
+  offer: LocalOfferIcon,
+  percent: PercentIcon,
 };
 
 export type IconName = keyof typeof ICONS;

--- a/frontend/src/components/atoms/index.ts
+++ b/frontend/src/components/atoms/index.ts
@@ -22,3 +22,4 @@ export { NumberInput } from './NumberInput';
 export { DatePicker } from './DatePicker';
 export { CurrencyField } from './CurrencyField';
 export { ProgressSpinner } from './ProgressSpinner';
+export { ChipTag } from './ChipTag';

--- a/frontend/src/components/molecules/PromotionBadge.docs.mdx
+++ b/frontend/src/components/molecules/PromotionBadge.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './PromotionBadge.stories';
+import { PromotionBadge } from './PromotionBadge';
+
+<Meta of={Stories} />
+
+# PromotionBadge
+
+Molecula que muestra una etiqueta promocional destacada.
+
+<Story id="molecules-promotionbadge--with-icon" />
+
+<ArgsTable of={PromotionBadge} story="WithIcon" />

--- a/frontend/src/components/molecules/PromotionBadge.stories.tsx
+++ b/frontend/src/components/molecules/PromotionBadge.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { PromotionBadge } from './PromotionBadge';
+
+const meta: Meta<typeof PromotionBadge> = {
+  title: 'Molecules/PromotionBadge',
+  component: PromotionBadge,
+  args: {
+    label: '20% OFF',
+    color: 'secondary',
+    withIcon: true,
+  },
+  argTypes: {
+    color: {
+      control: 'select',
+      options: [
+        'default',
+        'primary',
+        'secondary',
+        'error',
+        'info',
+        'success',
+        'warning',
+      ],
+    },
+    withIcon: { control: 'boolean' },
+    onClick: { action: 'clicked' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof PromotionBadge>;
+
+export const WithIcon: Story = {};
+
+export const WithoutIcon: Story = {
+  args: { withIcon: false, label: 'PROMO' },
+};

--- a/frontend/src/components/molecules/PromotionBadge.test.tsx
+++ b/frontend/src/components/molecules/PromotionBadge.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from '../../theme';
+import { PromotionBadge } from './PromotionBadge';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('PromotionBadge', () => {
+  it('renders promotion text', () => {
+    renderWithTheme(<PromotionBadge label="2x1" />);
+    expect(screen.getByText('2x1')).toBeInTheDocument();
+  });
+
+  it('shows icon when withIcon is true', () => {
+    const { container } = renderWithTheme(<PromotionBadge label="Oferta" withIcon />);
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('applies color class', () => {
+    const { container } = renderWithTheme(
+      <PromotionBadge label="Promo" color="secondary" />,
+    );
+    const chip = container.querySelector('.MuiChip-root') as HTMLElement;
+    expect(chip).toHaveClass('MuiChip-colorSecondary');
+  });
+
+  it('calls onClick when clicked', async () => {
+    const user = userEvent.setup();
+    const handleClick = jest.fn();
+    renderWithTheme(<PromotionBadge label="Promo" onClick={handleClick} />);
+    await user.click(screen.getByRole('button', { name: /promo/i }));
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/molecules/PromotionBadge.tsx
+++ b/frontend/src/components/molecules/PromotionBadge.tsx
@@ -1,0 +1,17 @@
+import { ChipTag, ChipTagProps, Icon } from '../atoms';
+import LocalOfferIcon from '@mui/icons-material/LocalOffer';
+
+export interface PromotionBadgeProps extends Omit<ChipTagProps, 'icon'> {
+  /** Mostrar ícono de oferta al inicio del chip */
+  withIcon?: boolean;
+}
+
+/**
+ * Etiqueta destacada para promociones o descuentos.
+ */
+export function PromotionBadge({ withIcon = false, ...props }: PromotionBadgeProps) {
+  const icon = withIcon ? <Icon icon={<LocalOfferIcon />} size="small" /> : undefined;
+  return <ChipTag icon={icon} {...props} />;
+}
+
+export default PromotionBadge;

--- a/frontend/src/components/molecules/index.ts
+++ b/frontend/src/components/molecules/index.ts
@@ -21,3 +21,4 @@ export { ProductListItem } from './ProductListItem';
 export { OrderListItem } from './OrderListItem';
 export { CustomerListItem } from './CustomerListItem';
 export { InventoryStatusItem } from './InventoryStatusItem';
+export { PromotionBadge } from './PromotionBadge';


### PR DESCRIPTION
## Summary
- add ChipTag atom and PromotionBadge molecule
- extend Icon atom with offer and percent icons
- document components in Storybook
- include unit tests for new components

## Testing
- `pnpm --filter ./frontend lint`
- `pnpm --filter ./frontend test`

------
https://chatgpt.com/codex/tasks/task_e_68515a145094832ba41249f25d4fcf5d