### PR TITLE
feat(notifications): add NotificationItem molecule

### DIFF
--- a/frontend/src/components/molecules/NotificationItem.docs.mdx
+++ b/frontend/src/components/molecules/NotificationItem.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './NotificationItem.stories';
+import { NotificationItem } from './NotificationItem';
+
+<Meta of={Stories} />
+
+# NotificationItem
+
+Molecula que representa una notificación individual en listados o menús.
+
+<Story id="molecules-notificationitem--info" />
+
+<ArgsTable of={NotificationItem} story="Info" />

--- a/frontend/src/components/molecules/NotificationItem.stories.tsx
+++ b/frontend/src/components/molecules/NotificationItem.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { NotificationItem } from './NotificationItem';
+
+const meta: Meta<typeof NotificationItem> = {
+  title: 'Molecules/NotificationItem',
+  component: NotificationItem,
+  args: {
+    message: 'Actualización disponible',
+    timestamp: 'hace 2 horas',
+    type: 'info',
+    read: false,
+  },
+  argTypes: {
+    type: { control: 'select', options: ['info', 'success', 'warning', 'error'] },
+    read: { control: 'boolean' },
+    onDismiss: { action: 'dismissed' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof NotificationItem>;
+
+export const Info: Story = {};
+
+export const WarningUnread: Story = {
+  args: { type: 'warning', message: 'Stock bajo en SKU123', timestamp: 'hace 5 min' },
+};
+
+export const SuccessRead: Story = {
+  args: { type: 'success', message: 'Pedido #1001 completado', read: true },
+};
+
+export const WithDismiss: Story = {
+  args: { onDismiss: () => {} },
+};

--- a/frontend/src/components/molecules/NotificationItem.test.tsx
+++ b/frontend/src/components/molecules/NotificationItem.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from '../../theme';
+import { NotificationItem } from './NotificationItem';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('NotificationItem', () => {
+  it('shows warning icon when type is warning', () => {
+    const { container } = renderWithTheme(
+      <NotificationItem type="warning" message="Atención" />,
+    );
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveClass('MuiSvgIcon-colorWarning');
+  });
+
+  it('renders message and timestamp', () => {
+    renderWithTheme(<NotificationItem message="Nuevo pedido" timestamp="hace 1 h" />);
+    expect(screen.getByText('Nuevo pedido')).toBeInTheDocument();
+    expect(screen.getByText('hace 1 h')).toBeInTheDocument();
+  });
+
+  it('hides unread dot when read', () => {
+    const { container } = renderWithTheme(<NotificationItem message="Leído" read />);
+    const badge = container.querySelector('.MuiBadge-badge') as HTMLElement;
+    expect(badge).toHaveClass('MuiBadge-invisible');
+  });
+
+  it('calls onDismiss when dismiss button clicked', async () => {
+    const user = userEvent.setup();
+    const handle = jest.fn();
+    renderWithTheme(<NotificationItem message="X" onDismiss={handle} />);
+    await user.click(screen.getByRole('button', { name: /dismiss notification/i }));
+    expect(handle).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/molecules/NotificationItem.tsx
+++ b/frontend/src/components/molecules/NotificationItem.tsx
@@ -1,0 +1,94 @@
+import CloseIcon from '@mui/icons-material/Close';
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
+import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import WarningAmberOutlinedIcon from '@mui/icons-material/WarningAmberOutlined';
+import { Badge, IconButton } from '../atoms';
+import { Box, Typography } from '@mui/material';
+import type { SvgIconProps } from '@mui/material/SvgIcon';
+import { ReactNode } from 'react';
+
+export interface NotificationItemProps {
+  /** Mensaje a mostrar en la notificación. */
+  message: ReactNode;
+  /** Fecha u hora relativa preformateada. */
+  timestamp?: ReactNode;
+  /** Tipo de notificación que determina el ícono y color. */
+  type?: 'info' | 'success' | 'warning' | 'error';
+  /** Indica si la notificación ya fue leída. */
+  read?: boolean;
+  /** Manejador para descartar la notificación. */
+  onDismiss?: () => void;
+}
+
+const ICON_MAP = {
+  info: InfoOutlinedIcon,
+  success: CheckCircleOutlineIcon,
+  warning: WarningAmberOutlinedIcon,
+  error: ErrorOutlineIcon,
+} as const;
+
+const COLOR_MAP: Record<
+  'info' | 'success' | 'warning' | 'error',
+  SvgIconProps['color']
+> = {
+  info: 'info',
+  success: 'success',
+  warning: 'warning',
+  error: 'error',
+};
+
+/**
+ * Elemento de una lista de notificaciones con icono, mensaje y marca temporal.
+ */
+export function NotificationItem({
+  message,
+  timestamp,
+  type = 'info',
+  read = false,
+  onDismiss,
+}: NotificationItemProps) {
+  const IconComponent = ICON_MAP[type];
+  const iconColor = COLOR_MAP[type];
+
+  return (
+    <Box
+      display="flex"
+      alignItems="center"
+      gap={1}
+      px={1}
+      py={0.5}
+      sx={{ bgcolor: read ? undefined : 'action.selected' }}
+    >
+      <Badge
+        variant="dot"
+        content={0}
+        color="primary"
+        invisible={read}
+        overlap="circular"
+      >
+        <IconComponent fontSize="small" color={iconColor} />
+      </Badge>
+      <Box flexGrow={1} minWidth={0}>
+        <Typography variant="body2" fontWeight={read ? 'normal' : 'bold'} noWrap>
+          {message}
+        </Typography>
+        {timestamp && (
+          <Typography variant="caption" color="text.secondary" noWrap>
+            {timestamp}
+          </Typography>
+        )}
+      </Box>
+      {onDismiss && (
+        <IconButton
+          aria-label="dismiss notification"
+          size="small"
+          onClick={onDismiss}
+          icon={<CloseIcon fontSize="small" />}
+        />
+      )}
+    </Box>
+  );
+}
+
+export default NotificationItem;

--- a/frontend/src/components/molecules/index.ts
+++ b/frontend/src/components/molecules/index.ts
@@ -22,3 +22,4 @@ export { OrderListItem } from './OrderListItem';
 export { CustomerListItem } from './CustomerListItem';
 export { InventoryStatusItem } from './InventoryStatusItem';
 export { PromotionBadge } from './PromotionBadge';
+export { NotificationItem } from './NotificationItem';


### PR DESCRIPTION
## Summary
- create `NotificationItem` molecule to display notification rows
- add stories and MDX docs for Storybook
- add unit tests verifying icon, read state and dismiss handler
- export molecule from component index

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68517ca8290c832b90f8e317b3cb105b