### PR TITLE
feat(ui): add CommentItem molecule

### DIFF
--- a/frontend/src/components/molecules/CommentItem.docs.mdx
+++ b/frontend/src/components/molecules/CommentItem.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './CommentItem.stories';
+import { CommentItem } from './CommentItem';
+
+<Meta of={Stories} />
+
+# CommentItem
+
+Molecula que representa un comentario o entrada en un historial.
+
+<Story id="molecules-commentitem--usuario" />
+
+<ArgsTable of={CommentItem} story="Usuario" />

--- a/frontend/src/components/molecules/CommentItem.stories.tsx
+++ b/frontend/src/components/molecules/CommentItem.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { CommentItem } from './CommentItem';
+
+const meta: Meta<typeof CommentItem> = {
+  title: 'Molecules/CommentItem',
+  component: CommentItem,
+  args: {
+    name: 'Ana Gómez',
+    text: 'Actualicé el precio del producto.',
+    timestamp: 'hace 3 horas',
+    avatarSrc: 'https://i.pravatar.cc/40',
+    system: false,
+  },
+  argTypes: {
+    system: { control: 'boolean' },
+    compact: { control: 'boolean' },
+    onEdit: { action: 'edit' },
+    onDelete: { action: 'delete' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof CommentItem>;
+
+export const Usuario: Story = {};
+
+export const Sistema: Story = {
+  args: {
+    system: true,
+    avatarSrc: undefined,
+    name: 'Sistema',
+    text: 'Pedido aprobado automáticamente',
+    timestamp: 'hace 1 día',
+  },
+};
+
+export const Compacto: Story = {
+  args: { compact: true },
+};
+
+export const ConAcciones: Story = {
+  args: {
+    onEdit: () => {},
+    onDelete: () => {},
+  },
+};

--- a/frontend/src/components/molecules/CommentItem.test.tsx
+++ b/frontend/src/components/molecules/CommentItem.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from '../../theme';
+import { CommentItem } from './CommentItem';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('CommentItem', () => {
+  it('muestra avatar y nombre del usuario', () => {
+    renderWithTheme(
+      <CommentItem name="Ana" text="Hola" avatarSrc="avatar.png" timestamp="ahora" />,
+    );
+    const img = screen.getByRole('img', { name: /ana/i });
+    expect(img).toHaveAttribute('src', 'avatar.png');
+    expect(screen.getByText('Ana')).toBeInTheDocument();
+  });
+
+  it('usa icono cuando es sistema', () => {
+    const { container } = renderWithTheme(
+      <CommentItem name="Sistema" text="Auto" timestamp="hoy" system />,
+    );
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+  });
+
+  it('muestra el texto completo y la fecha', () => {
+    renderWithTheme(<CommentItem name="Ana" text="Un texto" timestamp="ayer" />);
+    expect(screen.getByText('Un texto')).toBeInTheDocument();
+    expect(screen.getByText('ayer')).toBeInTheDocument();
+  });
+
+  it('dispara callbacks de acciones', async () => {
+    const user = userEvent.setup();
+    const handleEdit = jest.fn();
+    const handleDelete = jest.fn();
+    renderWithTheme(
+      <CommentItem
+        name="Ana"
+        text="X"
+        timestamp="hoy"
+        onEdit={handleEdit}
+        onDelete={handleDelete}
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: /editar comentario/i }));
+    await user.click(screen.getByRole('button', { name: /eliminar comentario/i }));
+    expect(handleEdit).toHaveBeenCalled();
+    expect(handleDelete).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/molecules/CommentItem.tsx
+++ b/frontend/src/components/molecules/CommentItem.tsx
@@ -1,0 +1,95 @@
+import { Box, Typography, Divider } from '@mui/material';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import { Avatar, Icon, IconButton } from '../atoms';
+import type { IconName } from '../atoms/Icon';
+import { ReactNode } from 'react';
+
+export interface CommentItemProps {
+  /** Nombre del autor o del sistema */
+  name: string;
+  /** Contenido principal del comentario */
+  text: ReactNode;
+  /** Marca de tiempo preformateada */
+  timestamp: ReactNode;
+  /** URL de la imagen del autor. Ignorado si `system` es true */
+  avatarSrc?: string;
+  /** Indica que el comentario proviene del sistema */
+  system?: boolean;
+  /** Nombre del ícono a mostrar cuando es evento del sistema */
+  systemIcon?: IconName;
+  /** Muestra versión compacta sin avatar ni nombre */
+  compact?: boolean;
+  /** Manejador para editar el comentario */
+  onEdit?: () => void;
+  /** Manejador para eliminar el comentario */
+  onDelete?: () => void;
+  /** Inserta un divisor debajo */
+  divider?: boolean;
+}
+
+/**
+ * Representa un comentario en hilos o historial de actividades.
+ */
+export function CommentItem({
+  name,
+  text,
+  timestamp,
+  avatarSrc,
+  system = false,
+  systemIcon = 'info',
+  compact = false,
+  onEdit,
+  onDelete,
+  divider = false,
+}: CommentItemProps) {
+  const leading = compact ? null : system ? (
+    <Icon name={systemIcon} color="info" />
+  ) : (
+    <Avatar alt={name} src={avatarSrc} size="small" />
+  );
+
+  return (
+    <>
+      <Box display="flex" alignItems="flex-start" gap={1} px={1} py={0.5}>
+        {leading}
+        <Box flexGrow={1} minWidth={0}>
+          {!compact && (
+            <Typography variant="body2" fontWeight="bold" noWrap>
+              {name}
+            </Typography>
+          )}
+          <Typography variant="body2" sx={{ whiteSpace: 'pre-line' }}>
+            {text}
+          </Typography>
+          <Typography variant="caption" color="text.secondary">
+            {timestamp}
+          </Typography>
+        </Box>
+        {(onEdit || onDelete) && (
+          <Box display="flex" gap={0.5}>
+            {onEdit && (
+              <IconButton
+                size="small"
+                aria-label="editar comentario"
+                onClick={onEdit}
+                icon={<EditIcon fontSize="small" />}
+              />
+            )}
+            {onDelete && (
+              <IconButton
+                size="small"
+                aria-label="eliminar comentario"
+                onClick={onDelete}
+                icon={<DeleteIcon fontSize="small" />}
+              />
+            )}
+          </Box>
+        )}
+      </Box>
+      {divider && <Divider />}
+    </>
+  );
+}
+
+export default CommentItem;

--- a/frontend/src/components/molecules/index.ts
+++ b/frontend/src/components/molecules/index.ts
@@ -23,3 +23,4 @@ export { CustomerListItem } from './CustomerListItem';
 export { InventoryStatusItem } from './InventoryStatusItem';
 export { PromotionBadge } from './PromotionBadge';
 export { NotificationItem } from './NotificationItem';
+export { CommentItem } from './CommentItem';


### PR DESCRIPTION
## Summary
- create `CommentItem` molecule with optional avatar, system icon and actions
- document usage in MDX and Storybook stories
- add unit tests
- export component from molecules index

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6851cc64226c832bbd6699107be18444