### PR TITLE
feat(ui): add ApprovalStepItem molecule

### DIFF
--- a/frontend/src/components/molecules/ApprovalStepItem.docs.mdx
+++ b/frontend/src/components/molecules/ApprovalStepItem.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './ApprovalStepItem.stories';
+import { ApprovalStepItem } from './ApprovalStepItem';
+
+<Meta of={Stories} />
+
+# ApprovalStepItem
+
+Molecula que representa una etapa en un flujo de aprobaci\u00f3n.
+
+<Story id="molecules-approvalstepitem--approved" />
+
+<ArgsTable of={ApprovalStepItem} story="Approved" />

--- a/frontend/src/components/molecules/ApprovalStepItem.stories.tsx
+++ b/frontend/src/components/molecules/ApprovalStepItem.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ApprovalStepItem } from './ApprovalStepItem';
+
+const meta: Meta<typeof ApprovalStepItem> = {
+  title: 'Molecules/ApprovalStepItem',
+  component: ApprovalStepItem,
+  args: {
+    name: 'Juan P.',
+    avatarSrc: 'https://i.pravatar.cc/40?img=3',
+    status: 'approved',
+    info: '01/05/2025',
+    orientation: 'horizontal',
+    current: false,
+  },
+  argTypes: {
+    status: { control: 'select', options: ['approved', 'pending', 'rejected'] },
+    orientation: { control: 'radio', options: ['horizontal', 'vertical'] },
+    current: { control: 'boolean' },
+    avatarSrc: { control: 'text' },
+    name: { control: 'text' },
+    info: { control: 'text' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof ApprovalStepItem>;
+
+export const Approved: Story = {};
+
+export const Pending: Story = {
+  args: {
+    status: 'pending',
+    name: 'Mar\u00eda S.',
+    avatarSrc: 'https://i.pravatar.cc/40?img=1',
+    info: undefined,
+  },
+};
+
+export const Rejected: Story = {
+  args: {
+    status: 'rejected',
+    name: 'Jos\u00e9 L.',
+    avatarSrc: 'https://i.pravatar.cc/40?img=2',
+    info: '01/06/2025',
+  },
+};
+
+export const VerticalTimeline: Story = {
+  args: { orientation: 'vertical' },
+};

--- a/frontend/src/components/molecules/ApprovalStepItem.test.tsx
+++ b/frontend/src/components/molecules/ApprovalStepItem.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider } from '../../theme';
+import { ApprovalStepItem } from './ApprovalStepItem';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('ApprovalStepItem', () => {
+  it('shows correct label and color for approved status', () => {
+    const { container } = renderWithTheme(
+      <ApprovalStepItem name="Juan" status="approved" />,
+    );
+    expect(screen.getByText('Aprobado')).toBeInTheDocument();
+    const chip = container.querySelector('.MuiChip-root') as HTMLElement;
+    expect(chip).toHaveClass('MuiChip-colorSuccess');
+  });
+
+  it('uses placeholder when no name', () => {
+    renderWithTheme(<ApprovalStepItem />);
+    expect(screen.getByText('Por asignar')).toBeInTheDocument();
+  });
+
+  it('renders info text', () => {
+    renderWithTheme(<ApprovalStepItem name="Ana" info="Paso 1 de 3" />);
+    expect(screen.getByText('Paso 1 de 3')).toBeInTheDocument();
+  });
+
+  it('applies vertical orientation', () => {
+    const { container } = renderWithTheme(
+      <ApprovalStepItem name="Ana" orientation="vertical" />,
+    );
+    const root = container.firstChild as HTMLElement;
+    expect(root).toHaveStyle({ flexDirection: 'column' });
+  });
+});

--- a/frontend/src/components/molecules/ApprovalStepItem.tsx
+++ b/frontend/src/components/molecules/ApprovalStepItem.tsx
@@ -1,0 +1,126 @@
+import { Box, Typography } from '@mui/material';
+import { Avatar } from '../atoms';
+import { Chip } from '../atoms/Chip';
+import { ReactNode } from 'react';
+
+export interface ApprovalStepItemProps {
+  /** Nombre del aprobador. */
+  name?: string;
+  /** URL de avatar. */
+  avatarSrc?: string;
+  /** Estado actual de la aprobaci\u00f3n. */
+  status?: 'approved' | 'pending' | 'rejected';
+  /** Fecha o posici\u00f3n ("Paso 1 de 3"). */
+  info?: ReactNode;
+  /** Orientaci\u00f3n de disposici\u00f3n. */
+  orientation?: 'horizontal' | 'vertical';
+  /** Resalta la etapa en curso. */
+  current?: boolean;
+}
+
+const STATUS_LABELS = {
+  approved: 'Aprobado',
+  pending: 'Pendiente',
+  rejected: 'Rechazado',
+} as const;
+
+const STATUS_COLORS = {
+  approved: 'success',
+  pending: 'warning',
+  rejected: 'error',
+} as const;
+
+/**
+ * Representa una etapa dentro de un flujo de aprobaci\u00f3n.
+ */
+export function ApprovalStepItem({
+  name,
+  avatarSrc,
+  status = 'pending',
+  info,
+  orientation = 'horizontal',
+  current = false,
+}: ApprovalStepItemProps) {
+  const displayName = name ?? 'Por asignar';
+  const initials =
+    !avatarSrc && name
+      ? name
+          .split(/\s+/)
+          .map((w) => w[0])
+          .slice(0, 2)
+          .join('')
+          .toUpperCase()
+      : undefined;
+
+  const content = (
+    <>
+      <Avatar alt={displayName} src={avatarSrc} size="small">
+        {initials}
+      </Avatar>
+      <Typography
+        variant="body2"
+        fontWeight={current ? 'bold' : 'normal'}
+        noWrap
+        textAlign={orientation === 'vertical' ? 'center' : 'inherit'}
+      >
+        {displayName}
+      </Typography>
+      {orientation === 'vertical' && (
+        <Chip
+          label={STATUS_LABELS[status]}
+          color={STATUS_COLORS[status]}
+          size="small"
+        />
+      )}
+      {orientation === 'vertical' && info && (
+        <Typography variant="caption" color="text.secondary">
+          {info}
+        </Typography>
+      )}
+    </>
+  );
+
+  if (orientation === 'vertical') {
+    return (
+      <Box
+        display="flex"
+        alignItems="center"
+        flexDirection="column"
+        gap={0.5}
+        px={1}
+        py={0.5}
+        sx={{ bgcolor: current ? 'action.selected' : undefined }}
+      >
+        {content}
+      </Box>
+    );
+  }
+
+  return (
+    <Box
+      display="flex"
+      alignItems="center"
+      gap={1}
+      px={1}
+      py={0.5}
+      sx={{ bgcolor: current ? 'action.selected' : undefined }}
+    >
+      <Avatar alt={displayName} src={avatarSrc} size="small">
+        {initials}
+      </Avatar>
+      <Box flexGrow={1} minWidth={0}>
+        <Typography variant="body2" fontWeight={current ? 'bold' : 'normal'} noWrap>
+          {displayName}
+        </Typography>
+        {info && (
+          <Typography variant="caption" color="text.secondary" noWrap>
+            {info}
+          </Typography>
+        )}
+      </Box>
+      <Chip label={STATUS_LABELS[status]} color={STATUS_COLORS[status]} size="small" />
+    </Box>
+  );
+}
+
+export default ApprovalStepItem;

--- a/frontend/src/components/molecules/index.ts
+++ b/frontend/src/components/molecules/index.ts
@@ -24,3 +24,4 @@ export { InventoryStatusItem } from './InventoryStatusItem';
 export { PromotionBadge } from './PromotionBadge';
 export { NotificationItem } from './NotificationItem';
 export { CommentItem } from './CommentItem';
+export { ApprovalStepItem } from './ApprovalStepItem';


### PR DESCRIPTION
## Summary
- add `ApprovalStepItem` molecule to show approval progress
- document in MDX and Storybook
- include tests and export in molecules index

## Testing
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_6852f3d4cfa8832bb0d88ec613b77942