### PR TITLE
feat(ui): add NavItem molecule

### DIFF
--- a/frontend/src/components/molecules/NavItem.docs.mdx
+++ b/frontend/src/components/molecules/NavItem.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './NavItem.stories';
+import { NavItem } from './NavItem';
+
+<Meta of={Stories} />
+
+# NavItem
+
+Elemento de navegación compuesto por ícono y texto para construir menús de forma consistente.
+
+<Story id="molecules-navitem--default" />
+
+<ArgsTable of={NavItem} story="Default" />

--- a/frontend/src/components/molecules/NavItem.stories.tsx
+++ b/frontend/src/components/molecules/NavItem.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import CheckroomIcon from '@mui/icons-material/Checkroom';
+import Inventory2Icon from '@mui/icons-material/Inventory2';
+import AssessmentIcon from '@mui/icons-material/Assessment';
+import { Box } from '@mui/material';
+import { NavItem } from './NavItem';
+
+const meta: Meta<typeof NavItem> = {
+  title: 'Molecules/NavItem',
+  component: NavItem,
+  args: {
+    icon: <CheckroomIcon />,
+    label: 'Productos',
+    href: '#',
+    active: false,
+    disabled: false,
+    collapsed: false,
+  },
+  argTypes: {
+    icon: { control: false },
+    label: { control: 'text' },
+    href: { control: 'text' },
+    active: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+    collapsed: { control: 'boolean' },
+    onClick: { action: 'clicked' },
+    badgeContent: { control: 'number' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof NavItem>;
+
+export const Default: Story = {};
+
+export const Active: Story = {
+  args: { active: true },
+};
+
+export const Disabled: Story = {
+  args: { disabled: true, icon: <AssessmentIcon />, label: 'Reportes' },
+};
+
+export const CollapsedMenu: Story = {
+  render: (args) => (
+    <Box display="flex" flexDirection="column" width={56} gap={1}>
+      <NavItem {...args} collapsed icon={<CheckroomIcon />} />
+      <NavItem {...args} collapsed icon={<Inventory2Icon />} label="Inventario" />
+      <NavItem {...args} collapsed icon={<AssessmentIcon />} label="Reportes" />
+    </Box>
+  ),
+};

--- a/frontend/src/components/molecules/NavItem.test.tsx
+++ b/frontend/src/components/molecules/NavItem.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Inventory2Icon from '@mui/icons-material/Inventory2';
+import { ThemeProvider } from '../../theme';
+import { NavItem } from './NavItem';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('NavItem', () => {
+  it('renders icon and text', () => {
+    renderWithTheme(<NavItem icon={<Inventory2Icon />} label="Inventario" />);
+    expect(screen.getByText('Inventario')).toBeInTheDocument();
+    expect(screen.getByLabelText('Inventario')).toBeInTheDocument();
+  });
+
+  it('calls onClick when clicked', async () => {
+    const user = userEvent.setup();
+    const handleClick = jest.fn();
+    renderWithTheme(
+      <NavItem icon={<Inventory2Icon />} label="Inventario" onClick={handleClick} />,
+    );
+    await user.click(screen.getByText('Inventario'));
+    expect(handleClick).toHaveBeenCalled();
+  });
+
+  it('applies aria-current when active', () => {
+    renderWithTheme(
+      <NavItem icon={<Inventory2Icon />} label="Inventario" href="#" active />,
+    );
+    expect(screen.getByRole('link', { name: 'Inventario' })).toHaveAttribute(
+      'aria-current',
+      'page',
+    );
+  });
+
+  it('shows tooltip when collapsed', async () => {
+    const user = userEvent.setup();
+    renderWithTheme(<NavItem icon={<Inventory2Icon />} label="Inventario" collapsed />);
+    const icon = screen.getByLabelText('Inventario');
+    await user.hover(icon);
+    expect(await screen.findByText('Inventario')).toBeInTheDocument();
+  });
+
+  it('does not trigger click when disabled', async () => {
+    const user = userEvent.setup();
+    const handleClick = jest.fn();
+    renderWithTheme(
+      <NavItem
+        icon={<Inventory2Icon />}
+        label="Inventario"
+        onClick={handleClick}
+        disabled
+      />,
+    );
+    await user.click(screen.getByLabelText('Inventario'));
+    expect(handleClick).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/molecules/NavItem.tsx
+++ b/frontend/src/components/molecules/NavItem.tsx
@@ -1,0 +1,88 @@
+import { Box, Typography } from '@mui/material';
+import { ReactElement } from 'react';
+import { Badge, Tooltip, Link } from '../atoms';
+
+export interface NavItemProps {
+  /** Ícono representativo de la sección */
+  icon: ReactElement;
+  /** Texto visible del ítem */
+  label: string;
+  /** Ruta de destino cuando es un enlace */
+  href?: string;
+  /** Indica que corresponde a la vista actual */
+  active?: boolean;
+  /** Deshabilita la interacción */
+  disabled?: boolean;
+  /** Muestra solo el ícono y despliega el texto como tooltip */
+  collapsed?: boolean;
+  /** Conteo opcional de notificaciones */
+  badgeContent?: number;
+  /** Manejador de clic */
+  onClick?: () => void;
+}
+
+/**
+ * Elemento de navegación con ícono y texto para menús laterales o superiores.
+ */
+export function NavItem({
+  icon,
+  label,
+  href,
+  active = false,
+  disabled = false,
+  collapsed = false,
+  badgeContent,
+  onClick,
+}: NavItemProps) {
+  const content = (
+    <Box
+      display="flex"
+      alignItems="center"
+      justifyContent={collapsed ? 'center' : 'flex-start'}
+      gap={1}
+      px={1.5}
+      py={1}
+      onClick={disabled ? undefined : onClick}
+      sx={{
+        cursor: disabled ? 'default' : onClick || href ? 'pointer' : 'default',
+        color: active ? 'primary.main' : disabled ? 'text.disabled' : undefined,
+        bgcolor: active ? 'action.selected' : undefined,
+        '&:hover': !disabled ? { bgcolor: 'action.hover' } : undefined,
+        borderRadius: 1,
+        textDecoration: 'none',
+      }}
+    >
+      {badgeContent !== undefined ? (
+        <Badge content={badgeContent} color="error" overlap="circular" showZero>
+          {icon}
+        </Badge>
+      ) : (
+        icon
+      )}
+      {!collapsed && (
+        <Typography variant="body2" fontWeight={active ? 'bold' : undefined} noWrap>
+          {label}
+        </Typography>
+      )}
+    </Box>
+  );
+
+  const Wrapper = href && !disabled ? Link : Box;
+  const wrapperProps = href && !disabled ? { href } : {};
+
+  const wrapped = (
+    <Wrapper
+      {...wrapperProps}
+      aria-current={active ? 'page' : undefined}
+      aria-disabled={disabled || undefined}
+      aria-label={label}
+      sx={{ textDecoration: 'none', display: 'block' }}
+    >
+      {content}
+    </Wrapper>
+  );
+
+  return collapsed ? <Tooltip title={label}>{wrapped}</Tooltip> : wrapped;
+}
+
+export default NavItem;

--- a/frontend/src/components/molecules/index.ts
+++ b/frontend/src/components/molecules/index.ts
@@ -25,3 +25,4 @@ export { PromotionBadge } from './PromotionBadge';
 export { NotificationItem } from './NotificationItem';
 export { CommentItem } from './CommentItem';
 export { ApprovalStepItem } from './ApprovalStepItem';
+export { NavItem } from './NavItem';


### PR DESCRIPTION
## Summary
- implement `NavItem` molecule for navigation menus
- document and demonstrate in Storybook
- add unit tests
- export molecule from index

## Testing
- `pnpm --filter ./frontend lint`
- `pnpm --filter ./frontend test`

------
https://chatgpt.com/codex/tasks/task_e_6853061108f0832ba8aa85b3687e693f