### PR TITLE
feat(ui): add BreadcrumbItem molecule

### DIFF
--- a/frontend/src/components/molecules/BreadcrumbItem.docs.mdx
+++ b/frontend/src/components/molecules/BreadcrumbItem.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './BreadcrumbItem.stories';
+import { BreadcrumbItem } from './BreadcrumbItem';
+
+<Meta of={Stories} />
+
+# BreadcrumbItem
+
+Eslabón de una ruta de navegación jerárquica.
+
+<Story id="molecules-breadcrumbitem--default" />
+
+<ArgsTable of={BreadcrumbItem} story="Default" />

--- a/frontend/src/components/molecules/BreadcrumbItem.stories.tsx
+++ b/frontend/src/components/molecules/BreadcrumbItem.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import { Box } from '@mui/material';
+import { BreadcrumbItem } from './BreadcrumbItem';
+
+const meta: Meta<typeof BreadcrumbItem> = {
+  title: 'Molecules/BreadcrumbItem',
+  component: BreadcrumbItem,
+  args: {
+    label: 'Inicio',
+    href: '#',
+    isLast: false,
+    separator: '/',
+  },
+  argTypes: {
+    label: { control: 'text' },
+    href: { control: 'text' },
+    isLast: { control: 'boolean' },
+    separator: { control: 'text' },
+    onNavigate: { action: 'navigated' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof BreadcrumbItem>;
+
+export const Default: Story = {};
+
+export const Current: Story = {
+  args: { isLast: true },
+};
+
+export const CustomSeparator: Story = {
+  args: { separator: <ChevronRightIcon fontSize="small" /> },
+};
+
+export const FullTrail: Story = {
+  render: (args) => (
+    <Box component="nav" aria-label="breadcrumb" display="flex" gap={0.5}>
+      <BreadcrumbItem {...args} label="Inicio" href="#" />
+      <BreadcrumbItem {...args} label="Catálogo" href="#" />
+      <BreadcrumbItem {...args} label="Verano 2025" href="#" />
+      <BreadcrumbItem {...args} label="Producto X" isLast />
+    </Box>
+  ),
+  parameters: { controls: { exclude: ['label', 'href', 'isLast', 'separator'] } },
+};

--- a/frontend/src/components/molecules/BreadcrumbItem.test.tsx
+++ b/frontend/src/components/molecules/BreadcrumbItem.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import { ThemeProvider } from '../../theme';
+import { BreadcrumbItem } from './BreadcrumbItem';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('BreadcrumbItem', () => {
+  it('renders link and calls onNavigate', async () => {
+    const user = userEvent.setup();
+    const handleNavigate = jest.fn();
+    renderWithTheme(
+      <BreadcrumbItem label="Inicio" href="/home" onNavigate={handleNavigate} />,
+    );
+    const link = screen.getByRole('link', { name: 'Inicio' });
+    expect(link).toHaveAttribute('href', '/home');
+    await user.click(link);
+    expect(handleNavigate).toHaveBeenCalledWith('/home');
+  });
+
+  it('marks last item with aria-current and no separator', () => {
+    renderWithTheme(<BreadcrumbItem label="Actual" isLast />);
+    const item = screen.getByText('Actual');
+    expect(item).toHaveAttribute('aria-current', 'page');
+    expect(screen.queryByText('/')).toBeNull();
+  });
+
+  it('renders custom separator', () => {
+    const { container } = renderWithTheme(
+      <BreadcrumbItem
+        label="Catálogo"
+        href="#"
+        separator={<ChevronRightIcon fontSize="small" />}
+      />,
+    );
+    expect(screen.getByRole('link', { name: 'Catálogo' })).toBeInTheDocument();
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/molecules/BreadcrumbItem.tsx
+++ b/frontend/src/components/molecules/BreadcrumbItem.tsx
@@ -1,0 +1,68 @@
+import { Box, Typography } from '@mui/material';
+import { ReactNode } from 'react';
+import { Link } from '../atoms';
+
+export interface BreadcrumbItemProps {
+  /** Texto del enlace */
+  label: string;
+  /** Ruta de destino */
+  href?: string;
+  /** Indica si es el último elemento */
+  isLast?: boolean;
+  /** Elemento separador entre items */
+  separator?: ReactNode;
+  /** Callback al hacer clic en el enlace */
+  onNavigate?: (href: string) => void;
+}
+
+/**
+ * Eslabón de un rastro de navegación jerárquica.
+ */
+export function BreadcrumbItem({
+  label,
+  href,
+  isLast = false,
+  separator = '/',
+  onNavigate,
+}: BreadcrumbItemProps) {
+  const handleClick: React.MouseEventHandler<HTMLAnchorElement> = (e) => {
+    e.preventDefault();
+    if (href) {
+      onNavigate?.(href);
+    }
+  };
+
+  const content =
+    href && !isLast ? (
+      <Link
+        href={href}
+        onClick={handleClick}
+        aria-current={isLast ? 'page' : undefined}
+      >
+        {label}
+      </Link>
+    ) : (
+      <Typography color="text.primary" aria-current={isLast ? 'page' : undefined}>
+        {label}
+      </Typography>
+    );
+
+  const separatorNode =
+    !isLast &&
+    (typeof separator === 'string' ? (
+      <Typography sx={{ mx: 0.5 }} color="text.disabled" aria-hidden="true">
+        {separator}
+      </Typography>
+    ) : (
+      separator
+    ));
+
+  return (
+    <Box display="inline-flex" alignItems="center">
+      {content}
+      {separatorNode}
+    </Box>
+  );
+}
+
+export default BreadcrumbItem;

--- a/frontend/src/components/molecules/index.ts
+++ b/frontend/src/components/molecules/index.ts
@@ -26,3 +26,4 @@ export { NotificationItem } from './NotificationItem';
 export { CommentItem } from './CommentItem';
 export { ApprovalStepItem } from './ApprovalStepItem';
 export { NavItem } from './NavItem';
+export { BreadcrumbItem } from './BreadcrumbItem';


### PR DESCRIPTION
## Summary
- create `BreadcrumbItem` molecule for breadcrumb navigation
- document component with MDX and Storybook stories
- add basic unit tests
- export from molecules index

## Testing
- `pnpm --filter erp-frontend lint`
- `pnpm --filter erp-frontend test`

------
https://chatgpt.com/codex/tasks/task_e_6853088db6d4832bac59543c24be406b