### PR TITLE
feat(ui): add PaginationControls molecule

### DIFF
--- a/frontend/src/components/molecules/PaginationControls.docs.mdx
+++ b/frontend/src/components/molecules/PaginationControls.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './PaginationControls.stories';
+import { PaginationControls } from './PaginationControls';
+
+<Meta of={Stories} />
+
+# PaginationControls
+
+Controles de paginación con botones anterior/siguiente y números.
+
+<Story id="molecules-paginationcontrols--default" />
+
+<ArgsTable of={PaginationControls} story="Default" />

--- a/frontend/src/components/molecules/PaginationControls.stories.tsx
+++ b/frontend/src/components/molecules/PaginationControls.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { PaginationControls } from './PaginationControls';
+
+const meta: Meta<typeof PaginationControls> = {
+  title: 'Molecules/PaginationControls',
+  component: PaginationControls,
+  args: { page: 1, totalPages: 10, showNumbers: true },
+  argTypes: {
+    onPageChange: { action: 'page changed' },
+    page: { control: { type: 'number', min: 1 } },
+    totalPages: { control: { type: 'number', min: 1 } },
+    showNumbers: { control: 'boolean' },
+    size: { control: 'radio', options: ['small', 'medium'] },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof PaginationControls>;
+
+export const Default: Story = {};
+export const Simple: Story = { args: { showNumbers: false } };
+export const LastPage: Story = { args: { page: 10 } };
+export const MiddlePage: Story = { args: { page: 5 } };

--- a/frontend/src/components/molecules/PaginationControls.test.tsx
+++ b/frontend/src/components/molecules/PaginationControls.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from '../../theme';
+import { PaginationControls } from './PaginationControls';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('PaginationControls', () => {
+  it('calls onPageChange when clicking next and prev', async () => {
+    const user = userEvent.setup();
+    const handleChange = jest.fn();
+    renderWithTheme(
+      <PaginationControls page={2} totalPages={5} onPageChange={handleChange} />,
+    );
+    await user.click(screen.getByRole('button', { name: /siguiente/i }));
+    expect(handleChange).toHaveBeenLastCalledWith(3);
+    await user.click(screen.getByRole('button', { name: /anterior/i }));
+    expect(handleChange).toHaveBeenLastCalledWith(1);
+  });
+
+  it('disables prev on first page and next on last page', () => {
+    renderWithTheme(
+      <PaginationControls page={1} totalPages={1} onPageChange={() => {}} />,
+    );
+    const prev = screen.getByRole('button', { name: /anterior/i });
+    const next = screen.getByRole('button', { name: /siguiente/i });
+    expect(prev).toBeDisabled();
+    expect(next).toBeDisabled();
+  });
+
+  it('jumps to page when clicking number', async () => {
+    const user = userEvent.setup();
+    const handleChange = jest.fn();
+    renderWithTheme(
+      <PaginationControls page={1} totalPages={3} onPageChange={handleChange} />,
+    );
+    await user.click(screen.getByRole('button', { name: '2' }));
+    expect(handleChange).toHaveBeenCalledWith(2);
+  });
+});

--- a/frontend/src/components/molecules/PaginationControls.tsx
+++ b/frontend/src/components/molecules/PaginationControls.tsx
@@ -1,0 +1,90 @@
+import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import { Box, Typography } from '@mui/material';
+import { IconButton, TertiaryButton } from '../atoms';
+
+export interface PaginationControlsProps {
+  /** Página actual comenzando en 1 */
+  page: number;
+  /** Número total de páginas */
+  totalPages: number;
+  /** Callback al cambiar de página */
+  onPageChange: (page: number) => void;
+  /** Muestra botones numéricos */
+  showNumbers?: boolean;
+  /** Tamaño de los controles */
+  size?: 'small' | 'medium';
+}
+
+/**
+ * Conjunto de botones de paginación para navegar entre páginas de listas.
+ */
+export function PaginationControls({
+  page,
+  totalPages,
+  onPageChange,
+  showNumbers = true,
+  size = 'medium',
+}: PaginationControlsProps) {
+  const disablePrev = page <= 1;
+  const disableNext = page >= totalPages;
+
+  const handlePrev = () => {
+    if (!disablePrev) {
+      onPageChange(page - 1);
+    }
+  };
+
+  const handleNext = () => {
+    if (!disableNext) {
+      onPageChange(page + 1);
+    }
+  };
+
+  const handlePageClick = (p: number) => () => {
+    if (p !== page) {
+      onPageChange(p);
+    }
+  };
+
+  return (
+    <Box display="flex" alignItems="center" gap={1}>
+      <IconButton
+        aria-label="anterior"
+        icon={<ChevronLeftIcon />}
+        onClick={handlePrev}
+        disabled={disablePrev}
+        size={size}
+      />
+      {showNumbers &&
+        Array.from({ length: totalPages }, (_, i) => {
+          const p = i + 1;
+          const isCurrent = p === page;
+          return (
+            <TertiaryButton
+              key={p}
+              onClick={handlePageClick(p)}
+              disabled={isCurrent}
+              aria-current={isCurrent ? 'page' : undefined}
+              size={size}
+              sx={{ fontWeight: isCurrent ? 'bold' : undefined }}
+            >
+              {p}
+            </TertiaryButton>
+          );
+        })}
+      <IconButton
+        aria-label="siguiente"
+        icon={<ChevronRightIcon />}
+        onClick={handleNext}
+        disabled={disableNext}
+        size={size}
+      />
+      <Typography variant="body2" ml={1}>
+        Página {page} de {totalPages}
+      </Typography>
+    </Box>
+  );
+}
+
+export default PaginationControls;

--- a/frontend/src/components/molecules/index.ts
+++ b/frontend/src/components/molecules/index.ts
@@ -27,3 +27,4 @@ export { CommentItem } from './CommentItem';
 export { ApprovalStepItem } from './ApprovalStepItem';
 export { NavItem } from './NavItem';
 export { BreadcrumbItem } from './BreadcrumbItem';
+export { PaginationControls } from './PaginationControls';


### PR DESCRIPTION
## Summary
- add PaginationControls molecule with prev/next buttons and optional page numbers
- document component in Storybook
- provide example stories and tests
- export PaginationControls in molecules index

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68530ec1f808832b8e49d6effe360fdb