### PR TITLE
feat(ui): add StepIndicator molecule

### DIFF
--- a/frontend/src/components/molecules/StepIndicator.docs.mdx
+++ b/frontend/src/components/molecules/StepIndicator.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './StepIndicator.stories';
+import { StepIndicator } from './StepIndicator';
+
+<Meta of={Stories} />
+
+# StepIndicator
+
+Representa un paso individual dentro de un flujo paso a paso.
+
+<Story id="molecules-stepindicator--demoflowhorizontal" />
+
+<ArgsTable of={StepIndicator} story="Default" />

--- a/frontend/src/components/molecules/StepIndicator.stories.tsx
+++ b/frontend/src/components/molecules/StepIndicator.stories.tsx
@@ -1,0 +1,53 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Box } from '@mui/material';
+import { StepIndicator } from './StepIndicator';
+
+const meta: Meta<typeof StepIndicator> = {
+  title: 'Molecules/StepIndicator',
+  component: StepIndicator,
+  args: {
+    step: 1,
+    label: 'Información',
+    status: 'pending',
+    orientation: 'horizontal',
+    connector: false,
+  },
+  argTypes: {
+    step: { control: { type: 'number', min: 1 } },
+    label: { control: 'text' },
+    status: { control: 'radio', options: ['pending', 'current', 'completed'] },
+    orientation: { control: 'radio', options: ['horizontal', 'vertical'] },
+    connector: { control: 'boolean' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof StepIndicator>;
+
+export const Default: Story = {};
+
+export const Current: Story = { args: { status: 'current' } };
+export const Completed: Story = { args: { status: 'completed' } };
+export const WithConnector: Story = { args: { connector: true } };
+
+export const DemoFlowHorizontal: Story = {
+  render: (args) => (
+    <Box display="flex" alignItems="center">
+      <StepIndicator {...args} step={1} label="Paso 1" status="completed" connector />
+      <StepIndicator {...args} step={2} label="Paso 2" status="current" connector />
+      <StepIndicator {...args} step={3} label="Paso 3" status="pending" />
+    </Box>
+  ),
+  parameters: { controls: { exclude: ['step', 'label', 'status', 'connector', 'orientation'] } },
+};
+
+export const DemoFlowVertical: Story = {
+  render: (args) => (
+    <Box display="flex" flexDirection="column" alignItems="center">
+      <StepIndicator {...args} step={1} label="Paso 1" status="completed" connector orientation="vertical" />
+      <StepIndicator {...args} step={2} label="Paso 2" status="current" connector orientation="vertical" />
+      <StepIndicator {...args} step={3} label="Paso 3" status="pending" orientation="vertical" />
+    </Box>
+  ),
+  parameters: { controls: { exclude: ['step', 'label', 'status', 'connector', 'orientation'] } },
+};

--- a/frontend/src/components/molecules/StepIndicator.test.tsx
+++ b/frontend/src/components/molecules/StepIndicator.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider } from '../../theme';
+import { StepIndicator } from './StepIndicator';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('StepIndicator', () => {
+  it('shows step number when pending', () => {
+    renderWithTheme(<StepIndicator step={2} label="Envio" />);
+    expect(screen.getByText('Envio')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+  });
+
+  it('shows check icon when completed', () => {
+    const { container } = renderWithTheme(
+      <StepIndicator step={1} label="Pago" status="completed" />,
+    );
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('marks current step with aria-current', () => {
+    renderWithTheme(
+      <StepIndicator step={3} label="Confirmar" status="current" />,
+    );
+    const root = screen.getByText('Confirmar').parentElement as HTMLElement;
+    expect(root).toHaveAttribute('aria-current', 'step');
+  });
+
+  it('renders vertical orientation with connector', () => {
+    const { container } = renderWithTheme(
+      <StepIndicator
+        step={1}
+        label="Datos"
+        orientation="vertical"
+        connector
+      />,
+    );
+    const divider = container.querySelector('.MuiDivider-root');
+    expect(divider).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/molecules/StepIndicator.tsx
+++ b/frontend/src/components/molecules/StepIndicator.tsx
@@ -1,0 +1,84 @@
+import CheckIcon from '@mui/icons-material/Check';
+import { Box, Divider, Typography } from '@mui/material';
+import { ReactNode } from 'react';
+
+export interface StepIndicatorProps {
+  /** Posición del paso comenzando en 1 */
+  step: number;
+  /** Texto o descripción del paso */
+  label: ReactNode;
+  /** Estado visual del paso */
+  status?: 'pending' | 'current' | 'completed';
+  /** Orientación de presentación */
+  orientation?: 'horizontal' | 'vertical';
+  /** Muestra una línea de conexión al siguiente paso */
+  connector?: boolean;
+}
+
+/**
+ * Representa un paso individual dentro de un flujo multi-paso.
+ */
+export function StepIndicator({
+  step,
+  label,
+  status = 'pending',
+  orientation = 'horizontal',
+  connector = false,
+}: StepIndicatorProps) {
+  const isCompleted = status === 'completed';
+  const isCurrent = status === 'current';
+
+  const bgColor = isCompleted
+    ? 'success.main'
+    : isCurrent
+    ? 'primary.main'
+    : 'background.paper';
+  const color = isCurrent || isCompleted ? 'common.white' : 'text.secondary';
+
+  const indicator = (
+    <Box
+      display="flex"
+      alignItems="center"
+      justifyContent="center"
+      width={24}
+      height={24}
+      borderRadius="50%"
+      bgcolor={bgColor}
+      color={color}
+      border={status === 'pending' ? '1px solid' : undefined}
+      borderColor="text.disabled"
+    >
+      {isCompleted ? <CheckIcon fontSize="small" /> : step}
+    </Box>
+  );
+
+  const divider = connector ? (
+    orientation === 'vertical' ? (
+      <Divider flexItem sx={{ alignSelf: 'stretch', my: 1 }} />
+    ) : (
+      <Divider orientation="vertical" flexItem sx={{ mx: 1 }} />
+    )
+  ) : null;
+
+  return (
+    <Box
+      display="flex"
+      alignItems="center"
+      flexDirection={orientation === 'vertical' ? 'column' : 'row'}
+      gap={0.5}
+      aria-current={isCurrent ? 'step' : undefined}
+    >
+      {indicator}
+      <Typography
+        variant="body2"
+        fontWeight={isCurrent ? 'bold' : 'normal'}
+        textAlign={orientation === 'vertical' ? 'center' : 'inherit'}
+      >
+        {label}
+      </Typography>
+      {divider}
+    </Box>
+  );
+}
+
+export default StepIndicator;

--- a/frontend/src/components/molecules/index.ts
+++ b/frontend/src/components/molecules/index.ts
@@ -28,3 +28,4 @@ export { ApprovalStepItem } from './ApprovalStepItem';
 export { NavItem } from './NavItem';
 export { BreadcrumbItem } from './BreadcrumbItem';
 export { PaginationControls } from './PaginationControls';
+export { StepIndicator } from './StepIndicator';


### PR DESCRIPTION
## Summary
- create `StepIndicator` molecule to show current, pending or completed step
- document usage with MDX and Storybook stories
- add unit tests
- export new molecule from index

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685320c85054832bbf179e52419a3225