### PR TITLE
feat(ui): add ModalHeader molecule

### DIFF
--- a/frontend/src/components/molecules/ModalHeader.docs.mdx
+++ b/frontend/src/components/molecules/ModalHeader.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './ModalHeader.stories';
+import { ModalHeader } from './ModalHeader';
+
+<Meta of={Stories} />
+
+# ModalHeader
+
+Encabezado estándar para cuadros de diálogo modal.
+
+<Story id="molecules-modalheader--default" />
+
+<ArgsTable of={ModalHeader} story="Default" />

--- a/frontend/src/components/molecules/ModalHeader.stories.tsx
+++ b/frontend/src/components/molecules/ModalHeader.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ModalHeader } from './ModalHeader';
+
+const meta: Meta<typeof ModalHeader> = {
+  title: 'Molecules/ModalHeader',
+  component: ModalHeader,
+  args: {
+    title: 'Editar Producto',
+    hideCloseButton: false,
+    align: 'left',
+    divider: false,
+  },
+  argTypes: {
+    title: { control: 'text' },
+    hideCloseButton: { control: 'boolean' },
+    align: { control: 'radio', options: ['left', 'center'] },
+    divider: { control: 'boolean' },
+    onClose: { action: 'close' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof ModalHeader>;
+
+export const Default: Story = {};
+
+export const WithoutClose: Story = {
+  args: { hideCloseButton: true },
+};
+
+export const CenteredTitle: Story = {
+  args: { align: 'center' },
+};
+
+export const WithDivider: Story = {
+  args: { divider: true },
+};
+
+export const LongTitle: Story = {
+  args: {
+    title:
+      'Este es un título de modal realmente muy largo para probar el comportamiento de envoltura o truncado',
+  },
+};

--- a/frontend/src/components/molecules/ModalHeader.test.tsx
+++ b/frontend/src/components/molecules/ModalHeader.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from '../../theme';
+import { ModalHeader } from './ModalHeader';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('ModalHeader', () => {
+  it('displays the title', () => {
+    renderWithTheme(<ModalHeader title="Detalles" />);
+    expect(screen.getByText('Detalles')).toBeInTheDocument();
+  });
+
+  it('shows close button by default', () => {
+    renderWithTheme(<ModalHeader title="X" />);
+    expect(screen.getByRole('button', { name: /cerrar/i })).toBeInTheDocument();
+  });
+
+  it('calls onClose when close button clicked', async () => {
+    const user = userEvent.setup();
+    const handleClose = jest.fn();
+    renderWithTheme(<ModalHeader title="X" onClose={handleClose} />);
+    await user.click(screen.getByRole('button', { name: /cerrar/i }));
+    expect(handleClose).toHaveBeenCalled();
+  });
+
+  it('hides close button when hideCloseButton true', () => {
+    renderWithTheme(<ModalHeader title="X" hideCloseButton />);
+    expect(screen.queryByRole('button', { name: /cerrar/i })).toBeNull();
+  });
+
+  it('centers title when align center', () => {
+    const { getByText } = renderWithTheme(
+      <ModalHeader title="Hola" align="center" hideCloseButton />,
+    );
+    const title = getByText('Hola');
+    expect(title).toHaveStyle({ textAlign: 'center' });
+  });
+});

--- a/frontend/src/components/molecules/ModalHeader.tsx
+++ b/frontend/src/components/molecules/ModalHeader.tsx
@@ -1,0 +1,57 @@
+import CloseIcon from '@mui/icons-material/Close';
+import { Box, Divider, Typography } from '@mui/material';
+import { IconButton } from '../atoms';
+import { ReactNode } from 'react';
+
+export interface ModalHeaderProps {
+  /** Título de la ventana modal */
+  title: ReactNode;
+  /** Manejador al hacer click en el botón de cerrar */
+  onClose?: () => void;
+  /** Oculta el botón de cerrar */
+  hideCloseButton?: boolean;
+  /** Alineación del título */
+  align?: 'left' | 'center';
+  /** Muestra un divisor inferior */
+  divider?: boolean;
+}
+
+/**
+ * Encabezado estándar para cuadros de diálogo/modal.
+ */
+export function ModalHeader({
+  title,
+  onClose,
+  hideCloseButton = false,
+  align = 'left',
+  divider = false,
+}: ModalHeaderProps) {
+  const header = (
+    <Box display="flex" alignItems="center" px={2} py={1}>
+      <Typography component="h2" variant="h5" flexGrow={1} textAlign={align} noWrap>
+        {title}
+      </Typography>
+      {!hideCloseButton && (
+        <IconButton
+          aria-label="Cerrar"
+          icon={<CloseIcon />}
+          size="small"
+          onClick={onClose}
+          sx={{ borderRadius: '50%' }}
+        />
+      )}
+      {hideCloseButton && align === 'center' && <Box width={32} />}
+    </Box>
+  );
+
+  return divider ? (
+    <Box>
+      {header}
+      <Divider />
+    </Box>
+  ) : (
+    header
+  );
+}
+
+export default ModalHeader;

--- a/frontend/src/components/molecules/index.ts
+++ b/frontend/src/components/molecules/index.ts
@@ -29,3 +29,4 @@ export { NavItem } from './NavItem';
 export { BreadcrumbItem } from './BreadcrumbItem';
 export { PaginationControls } from './PaginationControls';
 export { StepIndicator } from './StepIndicator';
+export { ModalHeader } from './ModalHeader';


### PR DESCRIPTION
## Summary
- create ModalHeader component for dialog headers
- add unit tests for ModalHeader
- document ModalHeader with Storybook stories and MDX docs
- export ModalHeader from molecules index

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6853256b4890832ba87c34a94735ad85