### PR TITLE
feat(ui): add ModalFooter molecule

### DIFF
--- a/frontend/src/components/molecules/ModalFooter.docs.mdx
+++ b/frontend/src/components/molecules/ModalFooter.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './ModalFooter.stories';
+import { ModalFooter } from './ModalFooter';
+
+<Meta of={Stories} />
+
+# ModalFooter
+
+Pie de un cuadro de diálogo modal que agrupa las acciones disponibles.
+
+<Story id="molecules-modalfooter--default" />
+
+<ArgsTable of={ModalFooter} story="Default" />

--- a/frontend/src/components/molecules/ModalFooter.stories.tsx
+++ b/frontend/src/components/molecules/ModalFooter.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ModalFooter } from './ModalFooter';
+
+const meta: Meta<typeof ModalFooter> = {
+  title: 'Molecules/ModalFooter',
+  component: ModalFooter,
+  args: {
+    primaryText: 'Guardar',
+    secondaryText: 'Cancelar',
+  },
+  argTypes: {
+    primaryText: { control: 'text' },
+    secondaryText: { control: 'text' },
+    primaryDisabled: { control: 'boolean' },
+    loading: { control: 'boolean' },
+    align: { control: 'radio', options: ['right', 'center'] },
+    onPrimary: { action: 'primary' },
+    onSecondary: { action: 'secondary' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof ModalFooter>;
+
+export const Default: Story = {};
+
+export const PrimaryDisabled: Story = {
+  args: { primaryDisabled: true },
+};
+
+export const Loading: Story = {
+  args: { loading: true },
+};
+
+export const SingleButton: Story = {
+  args: { secondaryText: undefined, onSecondary: undefined, align: 'center' },
+};

--- a/frontend/src/components/molecules/ModalFooter.test.tsx
+++ b/frontend/src/components/molecules/ModalFooter.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from '../../theme';
+import { ModalFooter } from './ModalFooter';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('ModalFooter', () => {
+  it('renders both buttons with text', () => {
+    renderWithTheme(
+      <ModalFooter
+        primaryText="Guardar"
+        onPrimary={() => {}}
+        secondaryText="Cancelar"
+        onSecondary={() => {}}
+      />,
+    );
+    expect(screen.getByRole('button', { name: /guardar/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /cancelar/i })).toBeInTheDocument();
+  });
+
+  it('calls handlers when clicked', async () => {
+    const user = userEvent.setup();
+    const onPrimary = jest.fn();
+    const onSecondary = jest.fn();
+    renderWithTheme(
+      <ModalFooter
+        primaryText="Guardar"
+        onPrimary={onPrimary}
+        secondaryText="Cancelar"
+        onSecondary={onSecondary}
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: /guardar/i }));
+    await user.click(screen.getByRole('button', { name: /cancelar/i }));
+    expect(onPrimary).toHaveBeenCalled();
+    expect(onSecondary).toHaveBeenCalled();
+  });
+
+  it('disables primary button when primaryDisabled', () => {
+    const onPrimary = jest.fn();
+    renderWithTheme(
+      <ModalFooter primaryText="Guardar" onPrimary={onPrimary} primaryDisabled />,
+    );
+    const btn = screen.getByRole('button', { name: /guardar/i });
+    expect(btn).toBeDisabled();
+    btn.click();
+    expect(onPrimary).not.toHaveBeenCalled();
+  });
+
+  it('shows spinner and blocks click when loading', () => {
+    const onPrimary = jest.fn();
+    renderWithTheme(
+      <ModalFooter primaryText="Guardar" onPrimary={onPrimary} loading />,
+    );
+    const btn = screen.getByRole('button');
+    expect(btn).toBeDisabled();
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    btn.click();
+    expect(onPrimary).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/molecules/ModalFooter.tsx
+++ b/frontend/src/components/molecules/ModalFooter.tsx
@@ -1,0 +1,48 @@
+import { Box } from '@mui/material';
+import { PrimaryButton, SecondaryButton } from '../atoms';
+import { ReactNode } from 'react';
+
+export interface ModalFooterProps {
+  /** Texto del botón primario */
+  primaryText: ReactNode;
+  /** Maneja el click del botón primario */
+  onPrimary: () => void;
+  /** Texto del botón secundario */
+  secondaryText?: ReactNode;
+  /** Maneja el click del botón secundario */
+  onSecondary?: () => void;
+  /** Deshabilita el botón primario */
+  primaryDisabled?: boolean;
+  /** Muestra spinner de carga en el botón primario */
+  loading?: boolean;
+  /** Alineación de los botones */
+  align?: 'right' | 'center';
+}
+
+/**
+ * Pie de un cuadro de diálogo/modal que agrupa las acciones disponibles.
+ */
+export function ModalFooter({
+  primaryText,
+  onPrimary,
+  secondaryText,
+  onSecondary,
+  primaryDisabled = false,
+  loading = false,
+  align = 'right',
+}: ModalFooterProps) {
+  const justifyContent = align === 'center' ? 'center' : 'flex-end';
+
+  return (
+    <Box display="flex" justifyContent={justifyContent} gap={1} px={2} py={2}>
+      {secondaryText && onSecondary && (
+        <SecondaryButton onClick={onSecondary}>{secondaryText}</SecondaryButton>
+      )}
+      <PrimaryButton onClick={onPrimary} disabled={primaryDisabled} loading={loading}>
+        {primaryText}
+      </PrimaryButton>
+    </Box>
+  );
+}
+
+export default ModalFooter;

--- a/frontend/src/components/molecules/index.ts
+++ b/frontend/src/components/molecules/index.ts
@@ -30,3 +30,4 @@ export { BreadcrumbItem } from './BreadcrumbItem';
 export { PaginationControls } from './PaginationControls';
 export { StepIndicator } from './StepIndicator';
 export { ModalHeader } from './ModalHeader';
+export { ModalFooter } from './ModalFooter';


### PR DESCRIPTION
## Summary
- add ModalFooter molecule with primary/secondary actions
- create unit tests
- provide Storybook stories and docs
- export ModalFooter from molecules index

## Testing
- `pnpm --filter ./frontend test`

------
https://chatgpt.com/codex/tasks/task_e_685327ddf924832bb8689ee604ae029d