### PR TITLE
feat(ui): add DismissibleAlert molecule

### DIFF
--- a/frontend/src/components/molecules/DismissibleAlert.docs.mdx
+++ b/frontend/src/components/molecules/DismissibleAlert.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './DismissibleAlert.stories';
+import { DismissibleAlert } from './DismissibleAlert';
+
+<Meta of={Stories} />
+
+# DismissibleAlert
+
+Alerta que puede cerrarse manualmente mediante un botón "X".
+
+<Story id="molecules-dismissiblealert--success" />
+
+<ArgsTable of={DismissibleAlert} story="Success" />

--- a/frontend/src/components/molecules/DismissibleAlert.stories.tsx
+++ b/frontend/src/components/molecules/DismissibleAlert.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { DismissibleAlert } from './DismissibleAlert';
+
+const meta: Meta<typeof DismissibleAlert> = {
+  title: 'Molecules/DismissibleAlert',
+  component: DismissibleAlert,
+  args: {
+    severity: 'success',
+    children: '¡Éxito! Producto guardado',
+  },
+  argTypes: {
+    severity: { control: 'select', options: ['error', 'warning', 'info', 'success'] },
+    defaultOpen: { control: 'boolean' },
+    onClose: { action: 'closed' },
+    children: { control: 'text' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof DismissibleAlert>;
+
+export const Success: Story = {};
+
+export const Error: Story = {
+  args: { severity: 'error', children: 'Ha ocurrido un error' },
+};
+
+export const Warning: Story = {
+  args: { severity: 'warning', children: 'Advertencia importante' },
+};
+
+export const Info: Story = {
+  args: { severity: 'info', children: 'Información para el usuario' },
+};

--- a/frontend/src/components/molecules/DismissibleAlert.test.tsx
+++ b/frontend/src/components/molecules/DismissibleAlert.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from '../../theme';
+import { DismissibleAlert } from './DismissibleAlert';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('DismissibleAlert', () => {
+  it('shows message text', () => {
+    renderWithTheme(<DismissibleAlert severity="success">Guardado</DismissibleAlert>);
+    expect(screen.getByText('Guardado')).toBeInTheDocument();
+  });
+
+  it('applies severity class', () => {
+    const { container } = renderWithTheme(
+      <DismissibleAlert severity="error">Error</DismissibleAlert>,
+    );
+    const root = container.firstChild as HTMLElement;
+    expect(root).toHaveClass('MuiAlert-standardError');
+  });
+
+  it('hides alert when close button clicked', async () => {
+    const user = userEvent.setup();
+    renderWithTheme(<DismissibleAlert severity="info">Info</DismissibleAlert>);
+    const btn = screen.getByRole('button', { name: /cerrar alerta/i });
+    await user.click(btn);
+    expect(screen.queryByText('Info')).toBeNull();
+  });
+
+  it('calls onClose callback', async () => {
+    const user = userEvent.setup();
+    const handle = jest.fn();
+    renderWithTheme(
+      <DismissibleAlert severity="info" onClose={handle}>
+        Hola
+      </DismissibleAlert>,
+    );
+    await user.click(screen.getByRole('button', { name: /cerrar alerta/i }));
+    expect(handle).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/molecules/DismissibleAlert.tsx
+++ b/frontend/src/components/molecules/DismissibleAlert.tsx
@@ -1,0 +1,50 @@
+import CloseIcon from '@mui/icons-material/Close';
+import { Alert, AlertProps, IconButton } from '../atoms';
+import { useState } from 'react';
+
+export interface DismissibleAlertProps extends Omit<AlertProps, 'onClose'> {
+  /** Manejador opcional al cerrar la alerta */
+  onClose?: () => void;
+  /** Controla si la alerta se muestra inicialmente */
+  defaultOpen?: boolean;
+}
+
+/**
+ * Combina `Alert` con un botón de cierre permitiendo descartar el mensaje.
+ */
+export function DismissibleAlert({
+  defaultOpen = true,
+  onClose,
+  children,
+  ...props
+}: DismissibleAlertProps) {
+  const [open, setOpen] = useState(defaultOpen);
+
+  const handleClose = () => {
+    setOpen(false);
+    onClose?.();
+  };
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <Alert
+      {...props}
+      action={
+        <IconButton
+          aria-label="Cerrar alerta"
+          size="small"
+          icon={<CloseIcon fontSize="small" />}
+          onClick={handleClose}
+          sx={{ borderRadius: '50%' }}
+        />
+      }
+    >
+      {children}
+    </Alert>
+  );
+}
+
+export default DismissibleAlert;

--- a/frontend/src/components/molecules/index.ts
+++ b/frontend/src/components/molecules/index.ts
@@ -31,3 +31,4 @@ export { PaginationControls } from './PaginationControls';
 export { StepIndicator } from './StepIndicator';
 export { ModalHeader } from './ModalHeader';
 export { ModalFooter } from './ModalFooter';
+export { DismissibleAlert } from './DismissibleAlert';


### PR DESCRIPTION
## Summary
- create `DismissibleAlert` molecule composed of `Alert` and close `IconButton`
- add storybook docs and stories
- add Jest tests
- export molecule from components index

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68532af80eb0832ba27f3f3d4e74484e