### PR TITLE
feat(ui): add FormActionGroup molecule

### DIFF
--- a/frontend/src/components/molecules/FormActionGroup.docs.mdx
+++ b/frontend/src/components/molecules/FormActionGroup.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './FormActionGroup.stories';
+import { FormActionGroup } from './FormActionGroup';
+
+<Meta of={Stories} />
+
+# FormActionGroup
+
+Sección de acciones para formularios con botones Guardar y Cancelar.
+
+<Story id="molecules-formactiongroup--default" />
+
+<ArgsTable of={FormActionGroup} story="Default" />

--- a/frontend/src/components/molecules/FormActionGroup.stories.tsx
+++ b/frontend/src/components/molecules/FormActionGroup.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { FormActionGroup } from './FormActionGroup';
+
+const meta: Meta<typeof FormActionGroup> = {
+  title: 'Molecules/FormActionGroup',
+  component: FormActionGroup,
+  args: {
+    primaryText: 'Guardar',
+    cancelText: 'Cancelar',
+  },
+  argTypes: {
+    primaryText: { control: 'text' },
+    cancelText: { control: 'text' },
+    cancelHref: { control: 'text' },
+    primaryDisabled: { control: 'boolean' },
+    loading: { control: 'boolean' },
+    align: { control: 'radio', options: ['right', 'spread'] },
+    onPrimary: { action: 'primary' },
+    onCancel: { action: 'cancel' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof FormActionGroup>;
+
+export const Default: Story = {};
+
+export const Disabled: Story = {
+  args: { primaryDisabled: true },
+};
+
+export const Loading: Story = {
+  args: { loading: true },
+};
+
+export const Spread: Story = {
+  args: { align: 'spread' },
+};

--- a/frontend/src/components/molecules/FormActionGroup.test.tsx
+++ b/frontend/src/components/molecules/FormActionGroup.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from '../../theme';
+import { FormActionGroup } from './FormActionGroup';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('FormActionGroup', () => {
+  it('renders cancel text and submit button', () => {
+    renderWithTheme(
+      <FormActionGroup primaryText="Guardar" onPrimary={() => {}} cancelText="Cancelar" />,
+    );
+    expect(screen.getByText('Cancelar')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /guardar/i })).toBeInTheDocument();
+  });
+
+  it('calls handlers when clicked', async () => {
+    const user = userEvent.setup();
+    const onPrimary = jest.fn();
+    const onCancel = jest.fn();
+    renderWithTheme(
+      <FormActionGroup
+        primaryText="Guardar"
+        onPrimary={onPrimary}
+        cancelText="Cancelar"
+        onCancel={onCancel}
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: /guardar/i }));
+    await user.click(screen.getByText('Cancelar'));
+    expect(onPrimary).toHaveBeenCalled();
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it('disables primary button when primaryDisabled', () => {
+    const onPrimary = jest.fn();
+    renderWithTheme(
+      <FormActionGroup primaryText="Guardar" onPrimary={onPrimary} primaryDisabled />,
+    );
+    const btn = screen.getByRole('button', { name: /guardar/i });
+    expect(btn).toBeDisabled();
+    btn.click();
+    expect(onPrimary).not.toHaveBeenCalled();
+  });
+
+  it('shows spinner and blocks click when loading', () => {
+    const onPrimary = jest.fn();
+    renderWithTheme(
+      <FormActionGroup primaryText="Guardar" onPrimary={onPrimary} loading />,
+    );
+    const btn = screen.getByRole('button');
+    expect(btn).toBeDisabled();
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    btn.click();
+    expect(onPrimary).not.toHaveBeenCalled();
+  });
+
+  it('applies cancel href when provided', () => {
+    renderWithTheme(
+      <FormActionGroup
+        primaryText="Guardar"
+        onPrimary={() => {}}
+        cancelText="Cancelar"
+        cancelHref="/home"
+      />,
+    );
+    expect(screen.getByRole('link', { name: /cancelar/i })).toHaveAttribute('href', '/home');
+  });
+});

--- a/frontend/src/components/molecules/FormActionGroup.tsx
+++ b/frontend/src/components/molecules/FormActionGroup.tsx
@@ -1,0 +1,51 @@
+import { Box } from '@mui/material';
+import { PrimaryButton, Link } from '../atoms';
+import { ReactNode } from 'react';
+
+export interface FormActionGroupProps {
+  /** Texto del botón principal del formulario */
+  primaryText: ReactNode;
+  /** Maneja la acción principal al enviar */
+  onPrimary: () => void;
+  /** Texto del enlace para cancelar */
+  cancelText?: ReactNode;
+  /** Acción al cancelar */
+  onCancel?: () => void;
+  /** Ruta opcional de navegación al cancelar */
+  cancelHref?: string;
+  /** Deshabilita el botón principal */
+  primaryDisabled?: boolean;
+  /** Muestra spinner de carga en el botón principal */
+  loading?: boolean;
+  /** Alineación de los controles */
+  align?: 'right' | 'spread';
+}
+
+/**
+ * Agrupa las acciones finales de un formulario, típicamente Guardar y Cancelar.
+ */
+export function FormActionGroup({
+  primaryText,
+  onPrimary,
+  cancelText = 'Cancelar',
+  onCancel,
+  cancelHref,
+  primaryDisabled = false,
+  loading = false,
+  align = 'right',
+}: FormActionGroupProps) {
+  const justifyContent = align === 'spread' ? 'space-between' : 'flex-end';
+
+  return (
+    <Box display="flex" width="100%" justifyContent={justifyContent} gap={1} mt={2}>
+      <Link href={cancelHref} onClick={onCancel} sx={{ alignSelf: 'center' }}>
+        {cancelText}
+      </Link>
+      <PrimaryButton onClick={onPrimary} disabled={primaryDisabled} loading={loading}>
+        {primaryText}
+      </PrimaryButton>
+    </Box>
+  );
+}
+
+export default FormActionGroup;

--- a/frontend/src/components/molecules/index.ts
+++ b/frontend/src/components/molecules/index.ts
@@ -32,3 +32,4 @@ export { StepIndicator } from './StepIndicator';
 export { ModalHeader } from './ModalHeader';
 export { ModalFooter } from './ModalFooter';
 export { DismissibleAlert } from './DismissibleAlert';
+export { FormActionGroup } from './FormActionGroup';


### PR DESCRIPTION
## Summary
- add `FormActionGroup` molecule to standardize form actions
- document the molecule in Storybook
- provide basic Storybook stories
- cover the component with unit tests
- export it in the molecules index

## Testing
- `npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_68532eb85930832b9c6a7575900cd2e1