### PR TITLE
Add FilterChip molecule

### DIFF
--- a/frontend/src/components/molecules/FilterChip.docs.mdx
+++ b/frontend/src/components/molecules/FilterChip.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './FilterChip.stories';
+import { FilterChip } from './FilterChip';
+
+<Meta of={Stories} />
+
+# FilterChip
+
+Chip que representa un filtro activo con opción de eliminarlo.
+
+<Story id="molecules-filterchip--default" />
+
+<ArgsTable of={FilterChip} story="Default" />

--- a/frontend/src/components/molecules/FilterChip.stories.tsx
+++ b/frontend/src/components/molecules/FilterChip.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Box } from '@mui/material';
+import { FilterChip } from './FilterChip';
+
+const meta: Meta<typeof FilterChip> = {
+  title: 'Molecules/FilterChip',
+  component: FilterChip,
+  args: {
+    id: 'category',
+    label: 'Categoría: Zapatos',
+    color: 'primary',
+  },
+  argTypes: {
+    id: { control: 'text' },
+    label: { control: 'text' },
+    color: {
+      control: 'select',
+      options: [
+        'default',
+        'primary',
+        'secondary',
+        'error',
+        'info',
+        'success',
+        'warning',
+      ],
+    },
+    variant: { control: 'radio', options: ['filled', 'outlined'] },
+    size: { control: 'radio', options: ['small', 'medium'] },
+    onRemove: { action: 'removed' },
+    maxWidth: { control: 'number' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof FilterChip>;
+
+export const Default: Story = {};
+
+export const LongText: Story = {
+  args: {
+    label: 'Nombre contiene: Zapatilla Deportiva Muy Larga',
+  },
+};
+
+export const Multiple: Story = {
+  render: (args) => (
+    <Box display="flex" gap={1} flexWrap="wrap">
+      <FilterChip {...args} id="color" label="Color: Rojo" />
+      <FilterChip {...args} id="size" label="Tamaño: Grande" />
+      <FilterChip {...args} id="brand" label="Marca: Adidas" />
+    </Box>
+  ),
+};

--- a/frontend/src/components/molecules/FilterChip.test.tsx
+++ b/frontend/src/components/molecules/FilterChip.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from '../../theme';
+import { FilterChip } from './FilterChip';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('FilterChip', () => {
+  it('renders the filter label', () => {
+    renderWithTheme(
+      <FilterChip id="color" label="Color: Rojo" onRemove={() => {}} />,
+    );
+    expect(screen.getByText('Color: Rojo')).toBeInTheDocument();
+  });
+
+  it('shows delete icon and triggers onRemove', async () => {
+    const user = userEvent.setup();
+    const handleRemove = jest.fn();
+    const { container } = renderWithTheme(
+      <FilterChip id="size" label="Talla: M" onRemove={handleRemove} />,
+    );
+    const icon = container.querySelector('.MuiChip-deleteIcon') as HTMLElement;
+    await user.click(icon);
+    expect(handleRemove).toHaveBeenCalledWith('size');
+  });
+
+  it('applies ellipsis style on long text', () => {
+    const { container } = renderWithTheme(
+      <FilterChip
+        id="name"
+        label="Nombre de filtro extremadamente largo que debe truncarse"
+        onRemove={() => {}}
+        maxWidth={120}
+      />,
+    );
+    const label = container.querySelector('.MuiChip-label') as HTMLElement;
+    expect(label).toHaveStyle({ textOverflow: 'ellipsis' });
+  });
+});

--- a/frontend/src/components/molecules/FilterChip.tsx
+++ b/frontend/src/components/molecules/FilterChip.tsx
@@ -1,0 +1,49 @@
+import { ChipTag, ChipTagProps, Icon } from '../atoms';
+
+export interface FilterChipProps
+  extends Omit<ChipTagProps, 'icon' | 'onDelete' | 'deleteIcon'> {
+  /** Identificador del filtro a remover */
+  id: string;
+  /** Manejador al quitar el filtro */
+  onRemove: (id: string) => void;
+  /** Ancho máximo antes de truncar con ellipsis */
+  maxWidth?: number;
+}
+
+/**
+ * Chip que representa un filtro activo y permite removerlo.
+ */
+export function FilterChip({
+  id,
+  label,
+  onRemove,
+  color = 'primary',
+  variant = 'filled',
+  maxWidth = 160,
+  sx,
+  ...props
+}: FilterChipProps) {
+  const sxProp = {
+    maxWidth,
+    '& .MuiChip-label': {
+      whiteSpace: 'nowrap',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+    },
+    ...sx,
+  };
+
+  return (
+    <ChipTag
+      label={label}
+      color={color}
+      variant={variant}
+      onDelete={() => onRemove(id)}
+      deleteIcon={<Icon name="close" size="small" />}
+      sx={sxProp}
+      {...props}
+    />
+  );
+}
+
+export default FilterChip;

--- a/frontend/src/components/molecules/index.ts
+++ b/frontend/src/components/molecules/index.ts
@@ -33,3 +33,4 @@ export { ModalHeader } from './ModalHeader';
 export { ModalFooter } from './ModalFooter';
 export { DismissibleAlert } from './DismissibleAlert';
 export { FormActionGroup } from './FormActionGroup';
+export { FilterChip } from './FilterChip';


### PR DESCRIPTION
## Summary
- add FilterChip molecule
- document FilterChip in Storybook
- add unit tests for FilterChip
- export component in molecules index

## Testing
- `npx jest --runTestsByPath frontend/src/components/molecules/FilterChip.test.tsx` *(fails: Need to install jest)*

------
https://chatgpt.com/codex/tasks/task_e_68533d5cb760832bb343551e148d52d8