### PR TITLE
feat(components): add TableRowItem molecule

### DIFF
--- a/frontend/src/components/molecules/TableRowItem.docs.mdx
+++ b/frontend/src/components/molecules/TableRowItem.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './TableRowItem.stories';
+import { TableRowItem } from './TableRowItem';
+
+<Meta of={Stories} />
+
+# TableRowItem
+
+Fila reutilizable para tablas.
+
+<Story id="molecules-tablerowitem--product-row" />
+
+<ArgsTable of={TableRowItem} story="ProductRow" />

--- a/frontend/src/components/molecules/TableRowItem.stories.tsx
+++ b/frontend/src/components/molecules/TableRowItem.stories.tsx
@@ -1,0 +1,73 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import dayjs from 'dayjs';
+import { ChipTag, Icon } from '../atoms';
+import { TableRowItem } from './TableRowItem';
+
+const meta: Meta<typeof TableRowItem> = {
+  title: 'Molecules/TableRowItem',
+  component: TableRowItem,
+  args: {
+    density: 'standard',
+    selected: false,
+    highlighted: false,
+  },
+  argTypes: {
+    onAction: { action: 'action' },
+    actionIcon: { control: false },
+    density: { control: 'radio', options: ['standard', 'compact'] },
+    selected: { control: 'boolean' },
+    highlighted: { control: 'boolean' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof TableRowItem>;
+
+export const ProductRow: Story = {
+  args: {
+    id: 'SKU001',
+    cells: [
+      'SKU001',
+      'Camisa Polo',
+      'Ropa',
+      '$49.99',
+      <ChipTag key="status" label="Activo" color="success" size="small" />,
+    ],
+    actionIcon: <Icon name="settings" />,
+  },
+};
+
+export const OrderRow: Story = {
+  args: {
+    id: 'O123',
+    cells: [
+      'O123',
+      dayjs('2024-05-01').format('DD/MM/YYYY'),
+      'Juan Perez',
+      '$100',
+      <ChipTag key="status" label="Pendiente" color="warning" size="small" />,
+    ],
+    actionIcon: <Icon name="info" />,
+  },
+};
+
+export const Selected: Story = {
+  args: {
+    ...ProductRow.args,
+    selected: true,
+  },
+};
+
+export const Highlighted: Story = {
+  args: {
+    ...ProductRow.args,
+    highlighted: true,
+  },
+};
+
+export const Compact: Story = {
+  args: {
+    ...ProductRow.args,
+    density: 'compact',
+  },
+};

--- a/frontend/src/components/molecules/TableRowItem.test.tsx
+++ b/frontend/src/components/molecules/TableRowItem.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from '../../theme';
+import { TableRowItem } from './TableRowItem';
+import { Icon } from '../atoms';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('TableRowItem', () => {
+  it('renders each cell value', () => {
+    renderWithTheme(
+      <table>
+        <tbody>
+          <TableRowItem cells={['SKU1', 'Camisa', 10]} />
+        </tbody>
+      </table>,
+    );
+    expect(screen.getByText('SKU1')).toBeInTheDocument();
+    expect(screen.getByText('Camisa')).toBeInTheDocument();
+    expect(screen.getByText('10')).toBeInTheDocument();
+  });
+
+  it('calls onAction with id', async () => {
+    const user = userEvent.setup();
+    const handle = jest.fn();
+    renderWithTheme(
+      <table>
+        <tbody>
+          <TableRowItem
+            id="row1"
+            cells={['A']}
+            actionIcon={<Icon name="settings" />}
+            onAction={handle}
+          />
+        </tbody>
+      </table>,
+    );
+    await user.click(screen.getByRole('button'));
+    expect(handle).toHaveBeenCalledWith('row1');
+  });
+
+  it('shows placeholder when cell value missing', () => {
+    renderWithTheme(
+      <table>
+        <tbody>
+          <TableRowItem cells={['SKU1', null, undefined]} />
+        </tbody>
+      </table>,
+    );
+    const cells = screen.getAllByText('-');
+    expect(cells).toHaveLength(2);
+  });
+
+  it('applies selected state', () => {
+    renderWithTheme(
+      <table>
+        <tbody>
+          <TableRowItem cells={['A']} selected />
+        </tbody>
+      </table>,
+    );
+    const row = screen.getByRole('row');
+    expect(row).toHaveClass('Mui-selected');
+  });
+});

--- a/frontend/src/components/molecules/TableRowItem.tsx
+++ b/frontend/src/components/molecules/TableRowItem.tsx
@@ -1,0 +1,62 @@
+import { TableRow, TableCell, Typography } from '@mui/material';
+import { IconButton } from '../atoms';
+import { ReactElement } from 'react';
+
+export interface TableRowItemProps {
+  /** Identificador de la fila para acciones */
+  id?: string | number;
+  /** Contenido de cada celda */
+  cells: Array<React.ReactNode | string | number | null | undefined>;
+  /** Icono del boton de accion */
+  actionIcon?: ReactElement;
+  /** Handler al hacer clic en la accion */
+  onAction?: (id: string | number | undefined) => void;
+  /** Densidad de la fila */
+  density?: 'standard' | 'compact';
+  /** Destacar temporalmente */
+  highlighted?: boolean;
+  /** Marcar como seleccionada */
+  selected?: boolean;
+}
+
+/**
+ * Representa una fila de tabla reutilizable.
+ */
+export function TableRowItem({
+  id,
+  cells,
+  actionIcon,
+  onAction,
+  density = 'standard',
+  highlighted = false,
+  selected = false,
+}: TableRowItemProps) {
+  const size = density === 'compact' ? 'small' : 'medium';
+
+  return (
+    <TableRow
+      hover
+      selected={selected}
+      sx={{ bgcolor: highlighted ? 'action.hover' : undefined }}
+    >
+      {cells.map((cell, index) => (
+        <TableCell key={index} size={size}>
+          {cell === null || cell === undefined ? (
+            <Typography variant="body2">-</Typography>
+          ) : typeof cell === 'string' || typeof cell === 'number' ? (
+            <Typography variant="body2">{cell}</Typography>
+          ) : (
+            cell
+          )}
+        </TableCell>
+      ))}
+      {actionIcon && onAction && (
+        <TableCell size={size} align="right">
+          <IconButton icon={actionIcon} onClick={() => onAction(id)} />
+        </TableCell>
+      )}
+    </TableRow>
+  );
+}
+
+export default TableRowItem;

--- a/frontend/src/components/molecules/index.ts
+++ b/frontend/src/components/molecules/index.ts
@@ -34,3 +34,4 @@ export { ModalFooter } from './ModalFooter';
 export { DismissibleAlert } from './DismissibleAlert';
 export { FormActionGroup } from './FormActionGroup';
 export { FilterChip } from './FilterChip';
+export { TableRowItem } from './TableRowItem';


### PR DESCRIPTION
## Summary
- create `TableRowItem` molecule for reusable table rows
- add Storybook stories and docs
- provide unit tests
- export molecule from components index

## Testing
- `pnpm install`
- `pnpm test`
- `ESLINT_USE_FLAT_CONFIG=false npx eslint "src/**/*.{ts,tsx}"` *(fails: plugin not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854012c552c832b9fee9cba6dbcdecd