### PR TITLE
Add PriceStepper molecule

### DIFF
--- a/frontend/src/components/molecules/PriceStepper.docs.mdx
+++ b/frontend/src/components/molecules/PriceStepper.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './PriceStepper.stories';
+import { PriceStepper } from './PriceStepper';
+
+<Meta of={Stories} />
+
+# PriceStepper
+
+Control para ajustar precios en centavos.
+
+<Story id="molecules-pricestepper--ajuste-libre" />
+
+<ArgsTable of={PriceStepper} story="AjusteLibre" />

--- a/frontend/src/components/molecules/PriceStepper.stories.tsx
+++ b/frontend/src/components/molecules/PriceStepper.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { PriceStepper } from './PriceStepper';
+
+const meta: Meta<typeof PriceStepper> = {
+  title: 'Molecules/PriceStepper',
+  component: PriceStepper,
+  args: {
+    value: 0,
+  },
+  argTypes: {
+    onChange: { action: 'changed' },
+    value: { control: 'number' },
+    min: { control: 'number' },
+    max: { control: 'number' },
+    step: { control: 'number' },
+    disabled: { control: 'boolean' },
+    readOnly: { control: 'boolean' },
+    size: { control: 'radio', options: ['small', 'medium'] },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof PriceStepper>;
+
+export const AjusteLibre: Story = {};
+
+export const AlcanzaMaximo: Story = {
+  args: { value: 0.95, max: 1 },
+};
+
+export const AlcanzaMinimo: Story = {
+  args: { value: 0.05, min: 0 },
+};
+
+export const ModoReadOnly: Story = {
+  args: { readOnly: true },
+};

--- a/frontend/src/components/molecules/PriceStepper.test.tsx
+++ b/frontend/src/components/molecules/PriceStepper.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { ThemeProvider } from '../../theme';
+import { PriceStepper } from './PriceStepper';
+
+function Wrapper(props: React.ComponentProps<typeof PriceStepper>) {
+  const [val, setVal] = React.useState(props.value);
+  return (
+    <PriceStepper
+      {...props}
+      value={val}
+      onChange={(v) => {
+        setVal(v);
+        props.onChange?.(v);
+      }}
+    />
+  );
+}
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('PriceStepper', () => {
+  it('shows the initial value', () => {
+    renderWithTheme(<PriceStepper value={1.23} onChange={() => {}} />);
+    const input = screen.getByRole('spinbutton') as HTMLInputElement;
+    expect(input.value).toBe('1.23');
+  });
+
+  it('increments up to max', async () => {
+    const user = userEvent.setup();
+    const handle = jest.fn();
+    renderWithTheme(<Wrapper value={0} max={0.05} onChange={handle} />);
+    const inc = screen.getByRole('button', { name: /incrementar/i });
+    for (let i = 0; i < 10; i++) {
+      try {
+        await user.click(inc);
+      } catch {
+        /* ignore */
+      }
+    }
+    expect(handle).toHaveBeenLastCalledWith(0.05);
+  });
+
+  it('normalizes out of range input', async () => {
+    const user = userEvent.setup();
+    renderWithTheme(<Wrapper value={0} min={0} max={1} />);
+    const input = screen.getByRole('spinbutton');
+    await user.clear(input);
+    await user.type(input, '10');
+    fireEvent.blur(input);
+    expect(input).toHaveValue(1);
+  });
+
+  it('emits numeric value', async () => {
+    const user = userEvent.setup();
+    const handle = jest.fn();
+    renderWithTheme(<PriceStepper value={0} onChange={handle} />);
+    await user.click(screen.getByRole('button', { name: /incrementar/i }));
+    expect(handle).toHaveBeenLastCalledWith(0.01);
+  });
+
+  it('handles arrow key increments', async () => {
+    const user = userEvent.setup();
+    const handle = jest.fn();
+    renderWithTheme(<Wrapper value={0} onChange={handle} />);
+    const input = screen.getByRole('spinbutton');
+    await user.click(input);
+    await user.keyboard('{ArrowUp}');
+    expect(handle).toHaveBeenLastCalledWith(0.01);
+    await user.keyboard('{ArrowDown}');
+    expect(handle).toHaveBeenLastCalledWith(0);
+  });
+});

--- a/frontend/src/components/molecules/PriceStepper.tsx
+++ b/frontend/src/components/molecules/PriceStepper.tsx
@@ -1,0 +1,160 @@
+import AddIcon from '@mui/icons-material/Add';
+import RemoveIcon from '@mui/icons-material/Remove';
+import { Box, Typography } from '@mui/material';
+import { IconButton, NumberInput, NumberInputProps, Tooltip } from '../atoms';
+
+export interface PriceStepperProps extends Pick<NumberInputProps, 'size'> {
+  /** Valor actual del precio */
+  value: number;
+  /** Callback con el nuevo precio */
+  onChange: (value: number) => void;
+  /** Valor mínimo permitido */
+  min?: number;
+  /** Valor máximo permitido */
+  max?: number;
+  /** Incremento/decremento en cada paso */
+  step?: number;
+  /** Deshabilita la interacción */
+  disabled?: boolean;
+  /** Solo lectura, sin editar */
+  readOnly?: boolean;
+}
+
+function clamp(value: number, min?: number, max?: number) {
+  if (min !== undefined) value = Math.max(min, value);
+  if (max !== undefined) value = Math.min(max, value);
+  return value;
+}
+
+const srOnly = {
+  position: 'absolute',
+  width: 1,
+  height: 1,
+  padding: 0,
+  margin: -1,
+  overflow: 'hidden',
+  clip: 'rect(0 0 0 0)',
+  whiteSpace: 'nowrap',
+  border: 0,
+} as const;
+
+/**
+ * Ajuste fino de precio con controles de incremento y decremento.
+ */
+export function PriceStepper({
+  value,
+  onChange,
+  min,
+  max,
+  step = 0.01,
+  disabled = false,
+  readOnly = false,
+  size = 'medium',
+}: PriceStepperProps) {
+  const handleInputChange: NumberInputProps['onChange'] = (_, val) => {
+    if (val === '') return;
+    onChange(clamp(Number(val.toFixed(2)), min, max));
+  };
+
+  const handleBlur: React.FocusEventHandler<HTMLInputElement> = (e) => {
+    const numeric = Number(e.target.value);
+    const normalized = clamp(numeric, min, max);
+    if (numeric !== normalized) {
+      onChange(normalized);
+    }
+  };
+
+  const precision = 100;
+  const round = (num: number) => Math.round(num * precision) / precision;
+
+  const increment = () => {
+    const next = clamp(round(value + step), min, max);
+    if (next !== value) {
+      onChange(next);
+    }
+  };
+
+  const decrement = () => {
+    const next = clamp(round(value - step), min, max);
+    if (next !== value) {
+      onChange(next);
+    }
+  };
+
+  const handleKeyDown: React.KeyboardEventHandler<HTMLInputElement> = (e) => {
+    if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      increment();
+    } else if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      decrement();
+    }
+  };
+
+  const atMin = min !== undefined && value <= min;
+  const atMax = max !== undefined && value >= max;
+  const disableDec = disabled || readOnly || atMin;
+  const disableInc = disabled || readOnly || atMax;
+
+  const tooltipDec =
+    atMin && !disabled && !readOnly ? 'Llegaste al m\u00EDnimo' : 'Disminuir \u2193';
+  const tooltipInc =
+    atMax && !disabled && !readOnly ? 'Llegaste al m\u00E1ximo' : 'Aumentar \u2191';
+
+  const digits = value.toFixed(2).length + 1;
+  const inputWidth = `${Math.max(digits, 6)}ch`;
+
+  return (
+    <Box
+      display="flex"
+      alignItems="center"
+      gap={1}
+      sx={{ opacity: disabled ? 0.4 : 1 }}
+    >
+      <Tooltip title={tooltipDec}>
+        <span>
+          <IconButton
+            aria-label="decrementar"
+            icon={<RemoveIcon />}
+            onClick={decrement}
+            disabled={disableDec}
+            size={size}
+          />
+        </span>
+      </Tooltip>
+      <NumberInput
+        value={Number(value.toFixed(2))}
+        onChange={handleInputChange}
+        onBlur={handleBlur}
+        disabled={disabled || readOnly}
+        min={min}
+        max={max}
+        size={size}
+        fullWidth={false}
+        inputProps={{
+          'aria-label': 'valor actual',
+          onKeyDown: handleKeyDown,
+          readOnly,
+          style: { textAlign: 'center' },
+        }}
+        sx={{ width: inputWidth }}
+      />
+      <Tooltip title={tooltipInc}>
+        <span>
+          <IconButton
+            aria-label="incrementar"
+            icon={<AddIcon />}
+            onClick={increment}
+            disabled={disableInc}
+            size={size}
+          />
+        </span>
+      </Tooltip>
+      <Typography sx={srOnly} aria-live="polite">
+        {value.toFixed(2)}
+      </Typography>
+    </Box>
+  );
+}
+
+export default PriceStepper;

--- a/frontend/src/components/molecules/index.ts
+++ b/frontend/src/components/molecules/index.ts
@@ -7,6 +7,7 @@ export { RadioButtonGroup } from './RadioButtonGroup';
 export { ToggleSwitchField } from './ToggleSwitchField';
 export { SearchBar } from './SearchBar';
 export { NumberStepper } from './NumberStepper';
+export { PriceStepper } from './PriceStepper';
 export { DateRangePicker } from './DateRangePicker';
 export { AvatarName } from './AvatarName';
 export { AvatarStatus } from './AvatarStatus';


### PR DESCRIPTION
## Summary
- implement `PriceStepper` molecule for fine‑grained pricing controls
- document `PriceStepper` stories and usage in Storybook
- add RTL tests for the new molecule
- export `PriceStepper` from molecules index
- refine width handling and rounding logic

## Testing
- `pnpm --filter ./frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68543773b10c832bbce158bbb7a5f045