### PR TITLE
feat(inventario): agrega StockLevelSlider

### DIFF
--- a/frontend/src/components/molecules/StockLevelSlider.docs.mdx
+++ b/frontend/src/components/molecules/StockLevelSlider.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './StockLevelSlider.stories';
+import { StockLevelSlider } from './StockLevelSlider';
+
+<Meta of={Stories} />
+
+# StockLevelSlider
+
+Control deslizante para indicar y ajustar el nivel de stock.
+
+<Story id="molecules-stocklevelslider--medium" />
+
+<ArgsTable of={StockLevelSlider} story="Medium" />

--- a/frontend/src/components/molecules/StockLevelSlider.stories.tsx
+++ b/frontend/src/components/molecules/StockLevelSlider.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { StockLevelSlider } from './StockLevelSlider';
+
+const meta: Meta<typeof StockLevelSlider> = {
+  title: 'Molecules/StockLevelSlider',
+  component: StockLevelSlider,
+  args: {
+    value: 50,
+  },
+  argTypes: {
+    onChange: { action: 'changed' },
+    onCommit: { action: 'committed' },
+    value: { control: 'number' },
+    readOnly: { control: 'boolean' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof StockLevelSlider>;
+
+export const Full: Story = {
+  args: { value: 100 },
+};
+
+export const Medium: Story = {
+  args: { value: 50 },
+};
+
+export const Critical: Story = {
+  args: { value: 10 },
+};
+
+export const Empty: Story = {
+  args: { value: 0 },
+};
+
+export const Locked: Story = {
+  args: { readOnly: true },
+};

--- a/frontend/src/components/molecules/StockLevelSlider.test.tsx
+++ b/frontend/src/components/molecules/StockLevelSlider.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ThemeProvider } from '../../theme';
+import { StockLevelSlider } from './StockLevelSlider';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('StockLevelSlider', () => {
+  it('changes color based on thresholds', () => {
+    const { container, rerender } = renderWithTheme(
+      <StockLevelSlider value={80} onChange={() => {}} />,
+    );
+    expect(screen.getByText('Alto')).toBeInTheDocument();
+    let chip = container.querySelector('.MuiChip-root') as HTMLElement;
+    expect(chip).toHaveClass('MuiChip-colorSuccess');
+
+    rerender(
+      <ThemeProvider>
+        <StockLevelSlider value={50} onChange={() => {}} />
+      </ThemeProvider>,
+    );
+    expect(screen.getByText('Medio')).toBeInTheDocument();
+    chip = container.querySelector('.MuiChip-root') as HTMLElement;
+    expect(chip).toHaveClass('MuiChip-colorWarning');
+
+    rerender(
+      <ThemeProvider>
+        <StockLevelSlider value={10} onChange={() => {}} />
+      </ThemeProvider>,
+    );
+    expect(screen.getByText('Crítico')).toBeInTheDocument();
+    chip = container.querySelector('.MuiChip-root') as HTMLElement;
+    expect(chip).toHaveClass('MuiChip-colorError');
+
+    rerender(
+      <ThemeProvider>
+        <StockLevelSlider value={0} onChange={() => {}} />
+      </ThemeProvider>,
+    );
+    expect(screen.getByText('Sin stock')).toBeInTheDocument();
+    chip = container.querySelector('.MuiChip-root') as HTMLElement;
+    expect(chip).toHaveClass('MuiChip-colorDefault');
+  });
+
+  it('is disabled when readOnly', () => {
+    renderWithTheme(<StockLevelSlider value={40} onChange={() => {}} readOnly />);
+    expect(screen.getByRole('slider')).toBeDisabled();
+  });
+
+  it('fires onChange with arrow keys', () => {
+    const handle = jest.fn();
+    renderWithTheme(<StockLevelSlider value={20} onChange={handle} step={1} />);
+    const slider = screen.getByRole('slider');
+    fireEvent.keyDown(slider, { key: 'ArrowRight' });
+    expect(handle).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/molecules/StockLevelSlider.tsx
+++ b/frontend/src/components/molecules/StockLevelSlider.tsx
@@ -1,0 +1,80 @@
+import { Box } from '@mui/material';
+import { useMemo } from 'react';
+import { Slider, Chip, SliderProps } from '../atoms';
+
+export interface StockLevelSliderProps
+  extends Omit<SliderProps, 'value' | 'onChange' | 'onChangeCommitted' | 'color'> {
+  /** Porcentaje actual de stock */
+  value: number;
+  /** Emite el valor mientras se arrastra */
+  onChange: (value: number) => void;
+  /** Emite el valor final al soltar */
+  onCommit?: (value: number) => void;
+  /** Deshabilita la modificaci\u00F3n */
+  readOnly?: boolean;
+}
+
+const LEVELS = [
+  { min: 71, label: 'Alto', color: 'success' },
+  { min: 30, label: 'Medio', color: 'warning' },
+  { min: 1, label: 'Cr\u00EDtico', color: 'error' },
+  { min: 0, label: 'Sin stock', color: 'default' },
+] as const;
+
+function getLevel(value: number) {
+  for (const level of LEVELS) {
+    if (value >= level.min) return level;
+  }
+  return LEVELS[LEVELS.length - 1];
+}
+
+/**
+ * Control de stock con retroalimentaci\u00F3n visual y badge de estado.
+ */
+export function StockLevelSlider({
+  value,
+  onChange,
+  onCommit,
+  readOnly = false,
+  min = 0,
+  max = 100,
+  step = 1,
+  sx,
+  ...rest
+}: StockLevelSliderProps) {
+  const level = useMemo(() => getLevel(value), [value]);
+  const ariaText = `${value} unidades, nivel ${level.label.toLowerCase()}`;
+
+  const handleChange: SliderProps['onChange'] = (_, val) => {
+    if (typeof val === 'number') {
+      onChange(val);
+    }
+  };
+
+  const handleCommit: SliderProps['onChangeCommitted'] = (_, val) => {
+    if (typeof val === 'number') {
+      onCommit?.(val);
+    }
+  };
+
+  return (
+    <Box display="flex" alignItems="center" gap={1}>
+      <Slider
+        value={value}
+        onChange={handleChange}
+        onChangeCommitted={handleCommit}
+        aria-valuetext={ariaText}
+        disabled={readOnly}
+        min={min}
+        max={max}
+        step={step}
+        color={level.color}
+        sx={{ flexGrow: 1, ...sx }}
+        {...rest}
+      />
+      <Chip label={level.label} color={level.color} size="small" />
+    </Box>
+  );
+}
+
+export default StockLevelSlider;

--- a/frontend/src/components/molecules/index.ts
+++ b/frontend/src/components/molecules/index.ts
@@ -36,3 +36,4 @@ export { DismissibleAlert } from './DismissibleAlert';
 export { FormActionGroup } from './FormActionGroup';
 export { FilterChip } from './FilterChip';
 export { TableRowItem } from './TableRowItem';
+export { StockLevelSlider } from './StockLevelSlider';


### PR DESCRIPTION
## Summary
- add StockLevelSlider molecule to edit stock visually
- document component in Storybook
- test slider behaviour and states
- export from molecules index

## Testing
- `pnpm --filter ./frontend lint`
- `pnpm --filter ./frontend test`

------
https://chatgpt.com/codex/tasks/task_e_6854899ab05c832ba8d277dd5ff32ba0