### PR TITLE
feat(ventas): agrega DiscountCheckboxGroup

### DIFF
--- a/frontend/src/components/molecules/DiscountCheckboxGroup.docs.mdx
+++ b/frontend/src/components/molecules/DiscountCheckboxGroup.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './DiscountCheckboxGroup.stories';
+import { DiscountCheckboxGroup } from './DiscountCheckboxGroup';
+
+<Meta of={Stories} />
+
+# DiscountCheckboxGroup
+
+Lista de casillas para combinar descuentos aplicables.
+
+<Story id="molecules-discountcheckboxgroup--todo-off" />
+
+<ArgsTable of={DiscountCheckboxGroup} story="TodoOff" />

--- a/frontend/src/components/molecules/DiscountCheckboxGroup.stories.tsx
+++ b/frontend/src/components/molecules/DiscountCheckboxGroup.stories.tsx
@@ -1,0 +1,67 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { DiscountCheckboxGroup, DiscountOption } from './DiscountCheckboxGroup';
+
+const options: DiscountOption[] = [
+  { id: '2x1', label: '2×1', category: 'Promo' },
+  { id: 'season', label: 'Fin de temporada' },
+  { id: 'employee', label: 'Precio Empleado' },
+];
+
+const conflicts = { employee: ['2x1'] };
+
+const meta: Meta<typeof DiscountCheckboxGroup> = {
+  title: 'Molecules/DiscountCheckboxGroup',
+  component: DiscountCheckboxGroup,
+  argTypes: {
+    value: { control: false },
+    onChange: { action: 'changed' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof DiscountCheckboxGroup>;
+
+export const TodoOff: Story = {
+  args: {
+    options,
+    value: [],
+  },
+};
+
+export const CombinacionValida: Story = {
+  render: function CombinacionValidaRender(args) {
+    const [value, setValue] = useState(['2x1', 'season']);
+    return (
+      <DiscountCheckboxGroup
+        {...args}
+        options={options}
+        value={value}
+        onChange={setValue}
+      />
+    );
+  },
+};
+
+export const ConflictoDetectado: Story = {
+  render: function ConflictoRender(args) {
+    const [value, setValue] = useState(['2x1']);
+    return (
+      <DiscountCheckboxGroup
+        {...args}
+        options={options}
+        conflicts={conflicts}
+        value={value}
+        onChange={setValue}
+      />
+    );
+  },
+};
+
+export const GrupoDeshabilitado: Story = {
+  args: {
+    options,
+    value: [],
+    disabled: true,
+  },
+};

--- a/frontend/src/components/molecules/DiscountCheckboxGroup.test.tsx
+++ b/frontend/src/components/molecules/DiscountCheckboxGroup.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from '../../theme';
+import { DiscountCheckboxGroup, DiscountOption } from './DiscountCheckboxGroup';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+const OPTIONS: DiscountOption[] = [
+  { id: '2x1', label: '2×1', category: 'Promo' },
+  { id: 'season', label: 'Fin de temporada' },
+  { id: 'employee', label: 'Precio Empleado' },
+];
+
+const CONFLICTS = { employee: ['2x1'] };
+
+describe('DiscountCheckboxGroup', () => {
+  it('toggles selection', async () => {
+    const user = userEvent.setup();
+    const handleChange = jest.fn();
+    renderWithTheme(
+      <DiscountCheckboxGroup options={OPTIONS} value={[]} onChange={handleChange} />,
+    );
+    const cb = screen.getByRole('checkbox', { name: /2×1/i });
+    await user.click(cb);
+    expect(handleChange).toHaveBeenCalledWith(['2x1']);
+  });
+
+  it('shows toast and disables conflicting option', async () => {
+    const user = userEvent.setup();
+    renderWithTheme(
+      <DiscountCheckboxGroup
+        options={OPTIONS}
+        value={['2x1']}
+        conflicts={CONFLICTS}
+        onChange={() => {}}
+      />,
+    );
+    const employee = screen.getByRole('checkbox', { name: /empleado/i });
+    await user.click(employee);
+    expect(employee).toBeDisabled();
+    expect(await screen.findByText(/no se puede combinar/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/molecules/DiscountCheckboxGroup.tsx
+++ b/frontend/src/components/molecules/DiscountCheckboxGroup.tsx
@@ -1,0 +1,107 @@
+import { Box, FormControlLabel, FormGroup, Typography } from '@mui/material';
+import WarningIcon from '@mui/icons-material/WarningAmber';
+import { useId, useState } from 'react';
+import { Checkbox, ChipTag, Snackbar } from '../atoms';
+
+export interface DiscountOption {
+  /** Identificador único */
+  id: string;
+  /** Texto visible de la opción */
+  label: string;
+  /** Categoría mostrada como chip */
+  category?: string;
+}
+
+export interface DiscountCheckboxGroupProps {
+  /** Opciones disponibles */
+  options: DiscountOption[];
+  /** Mapeo de id a ids incompatibles */
+  conflicts?: Record<string, string[]>;
+  /** Conjunto de ids seleccionados */
+  value: string[];
+  /** Callback cuando cambia la selección */
+  onChange: (value: string[]) => void;
+  /** Etiqueta del grupo */
+  label?: string;
+  /** Deshabilita todo el grupo */
+  disabled?: boolean;
+}
+
+/**
+ * Lista de descuentos combinables con manejo de conflictos.
+ */
+export function DiscountCheckboxGroup({
+  options,
+  conflicts = {},
+  value,
+  onChange,
+  label,
+  disabled = false,
+}: DiscountCheckboxGroupProps) {
+  const [toast, setToast] = useState<string | null>(null);
+  const [disabledIds, setDisabledIds] = useState<string[]>([]);
+  const generatedId = useId();
+  const groupId = label ? generatedId : undefined;
+
+  const handleClose = () => setToast(null);
+
+  const handleToggle = (id: string) => {
+    if (value.includes(id)) {
+      onChange(value.filter((v) => v !== id));
+      return;
+    }
+    const conflictsWith = conflicts[id]?.find((c) => value.includes(c));
+    if (conflictsWith) {
+      const otherLabel = options.find((o) => o.id === conflictsWith)?.label;
+      setToast(
+        `\u00ab${options.find((o) => o.id === id)?.label}\u00bb no se puede combinar con \u00ab${otherLabel}\u00bb`,
+      );
+      setDisabledIds((prev) => [...prev, id]);
+      return;
+    }
+    onChange([...value, id]);
+  };
+
+  return (
+    <Box>
+      {label && (
+        <Typography id={groupId} variant="subtitle1" mb={1}>
+          {label}
+        </Typography>
+      )}
+      <FormGroup aria-labelledby={groupId}>
+        {options.map((opt) => {
+          const checked = value.includes(opt.id);
+          const conflict = disabledIds.includes(opt.id);
+          return (
+            <Box
+              key={opt.id}
+              display="flex"
+              alignItems="center"
+              gap={1}
+              sx={{ color: conflict ? 'error.main' : undefined }}
+            >
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={checked}
+                    disabled={disabled || conflict}
+                    onChange={() => handleToggle(opt.id)}
+                  />
+                }
+                label={opt.label}
+              />
+              {opt.category && (
+                <ChipTag label={opt.category} size="small" color="secondary" />
+              )}
+              {conflict && <WarningIcon color="error" fontSize="small" />}
+            </Box>
+          );
+        })}
+      </FormGroup>
+      <Snackbar open={Boolean(toast)} message={toast} onClose={handleClose} />
+    </Box>
+  );
+}
+
+export default DiscountCheckboxGroup;

--- a/frontend/src/components/molecules/index.ts
+++ b/frontend/src/components/molecules/index.ts
@@ -37,3 +37,4 @@ export { FormActionGroup } from './FormActionGroup';
 export { FilterChip } from './FilterChip';
 export { TableRowItem } from './TableRowItem';
 export { StockLevelSlider } from './StockLevelSlider';
+export { DiscountCheckboxGroup } from './DiscountCheckboxGroup';


### PR DESCRIPTION
## Summary
- create `DiscountCheckboxGroup` molecule for combining discounts
- add related Storybook stories and docs
- implement RTL tests
- export component from molecules index

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68549eb4a088832b80ab6bcdc18059d8