### PR TITLE
feat(frontend): add ImageUpload component

### DIFF
--- a/frontend/src/components/molecules/ImageUpload.docs.mdx
+++ b/frontend/src/components/molecules/ImageUpload.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './ImageUpload.stories';
+import { ImageUpload } from './ImageUpload';
+
+<Meta of={Stories} />
+
+# ImageUpload
+
+Componente para subir la foto hero o miniaturas de looks.
+
+<Story id="molecules-imageupload--vacío" />
+
+<ArgsTable of={ImageUpload} />

--- a/frontend/src/components/molecules/ImageUpload.stories.tsx
+++ b/frontend/src/components/molecules/ImageUpload.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ImageUpload } from './ImageUpload';
+
+const meta: Meta<typeof ImageUpload> = {
+  title: 'Molecules/ImageUpload',
+  component: ImageUpload,
+  parameters: {
+    controls: { exclude: ['uploadFn', 'onChange'] },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof ImageUpload>;
+
+export const Vacío: Story = {};
+export const Arrastrando: Story = {
+  render: (args) => <ImageUpload {...args} />,
+  play: async ({ canvasElement }) => {
+    const dropzone = canvasElement.querySelector('[data-testid="dropzone"]');
+    dropzone?.dispatchEvent(new DragEvent('dragover', { bubbles: true }));
+  },
+};
+export const Subiendo: Story = {
+  args: {
+    uploadFn: () => new Promise(() => {}),
+  },
+  play: async ({ canvasElement }) => {
+    const dropzone = canvasElement.querySelector('[data-testid="dropzone"]');
+    dropzone?.dispatchEvent(new DragEvent('dragover', { bubbles: true }));
+  },
+};
+export const Cargado: Story = {
+  args: { value: 'https://picsum.photos/128' },
+};
+export const FormatoInválido: Story = {
+  args: {
+    uploadFn: () => Promise.reject(new Error('Formato inválido')),
+  },
+};

--- a/frontend/src/components/molecules/ImageUpload.test.tsx
+++ b/frontend/src/components/molecules/ImageUpload.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ImageUpload } from './ImageUpload';
+import { ThemeProvider } from '../../theme';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('ImageUpload', () => {
+  it('sube imagen exitosamente', async () => {
+    const mockUpload = jest.fn(async () => {
+      await new Promise((r) => setTimeout(r, 200));
+      return 'https://cdn.test/image.jpg';
+    });
+    renderWithTheme(<ImageUpload uploadFn={mockUpload} />);
+    const file = new File(['foto'], 'foto.jpg', { type: 'image/jpeg' });
+    const input = screen.getByTestId('file-input') as HTMLInputElement;
+    await userEvent.upload(input, file);
+    expect(mockUpload).toHaveBeenCalled();
+    await waitFor(() =>
+      expect(screen.getByRole('img')).toHaveAttribute(
+        'src',
+        'https://cdn.test/image.jpg',
+      ),
+    );
+  });
+
+  it('muestra error en formato inválido', async () => {
+    const mockUpload = jest.fn(async () => {
+      await new Promise((r) => setTimeout(r, 200));
+      throw new Error('413');
+    });
+    renderWithTheme(<ImageUpload uploadFn={mockUpload} mimeTypes={['image/png']} />);
+    const file = new File(['foto'], 'foto.jpg', { type: 'image/jpeg' });
+    const input = screen.getByTestId('file-input') as HTMLInputElement;
+    await userEvent.upload(input, file);
+    expect(mockUpload).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/molecules/ImageUpload.tsx
+++ b/frontend/src/components/molecules/ImageUpload.tsx
@@ -1,0 +1,172 @@
+import { Box, Typography } from '@mui/material';
+import CloudUploadIcon from '@mui/icons-material/CloudUpload';
+import { useRef, useState, DragEvent, ChangeEvent } from 'react';
+import { Avatar, ProgressSpinner, Snackbar, Badge } from '../atoms';
+
+export interface ImageUploadProps {
+  /** URL de la imagen cargada */
+  value?: string;
+  /** Llamada que sube el archivo y devuelve la URL final */
+  uploadFn?: (file: File) => Promise<string>;
+  /** Peso máximo en bytes */
+  maxSize?: number;
+  /** Tipos MIME permitidos */
+  mimeTypes?: string[];
+  /** Callback cuando la carga finaliza exitosamente */
+  onChange?: (url: string) => void;
+}
+
+type Status = 'idle' | 'dragging' | 'uploading' | 'success' | 'error';
+
+export function ImageUpload({
+  value,
+  uploadFn = async (file) => URL.createObjectURL(file),
+  maxSize = 5 * 1024 * 1024,
+  mimeTypes = ['image/jpeg', 'image/png'],
+  onChange,
+}: ImageUploadProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [status, setStatus] = useState<Status>('idle');
+  const [preview, setPreview] = useState<string | undefined>(value);
+  const [snackbar, setSnackbar] = useState<{ open: boolean; message: string }>({
+    open: false,
+    message: '',
+  });
+
+  const resetDrag = () => setStatus((s) => (s === 'dragging' ? 'idle' : s));
+
+  const handleFiles = async (files: FileList | null) => {
+    if (!files || files.length === 0) return;
+    const file = files[0];
+    if (file.size > maxSize || !mimeTypes.includes(file.type)) {
+      setStatus('error');
+      setSnackbar({ open: true, message: 'Formato o tamaño inválido' });
+      return;
+    }
+    setPreview(URL.createObjectURL(file));
+    setStatus('uploading');
+    try {
+      const url = await uploadFn(file);
+      setPreview(url);
+      setStatus('success');
+      setSnackbar({ open: true, message: 'Imagen subida' });
+      onChange?.(url);
+    } catch {
+      setStatus('error');
+      setSnackbar({ open: true, message: 'Error al subir imagen' });
+    }
+  };
+
+  const onDrop = (e: DragEvent) => {
+    e.preventDefault();
+    resetDrag();
+    handleFiles(e.dataTransfer.files);
+  };
+
+  const openFile = () => inputRef.current?.click();
+
+  const onInputChange = (e: ChangeEvent<HTMLInputElement>) => {
+    handleFiles(e.target.files);
+  };
+
+  const borderColor =
+    status === 'dragging'
+      ? 'info.main'
+      : status === 'error'
+        ? 'error.main'
+        : 'grey.400';
+
+  return (
+    <Box position="relative" width={128} height={128}>
+      <Box
+        component="div"
+        onClick={openFile}
+        onDragOver={(e) => {
+          e.preventDefault();
+          setStatus('dragging');
+        }}
+        onDragLeave={resetDrag}
+        onDrop={onDrop}
+        sx={{
+          width: 128,
+          height: 128,
+          border: '2px dashed',
+          borderColor,
+          borderRadius: 1,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          overflow: 'hidden',
+          position: 'relative',
+          cursor: 'pointer',
+          bgcolor: 'grey.100',
+        }}
+        data-testid="dropzone"
+        data-error={status === 'error'}
+      >
+        {preview ? (
+          <Avatar src={preview} variant="rounded" sx={{ width: 128, height: 128 }} />
+        ) : (
+          <Avatar sx={{ width: 128, height: 128, bgcolor: 'grey.300' }}>
+            <CloudUploadIcon fontSize="large" />
+          </Avatar>
+        )}
+        {status === 'uploading' && (
+          <Box
+            position="absolute"
+            top={0}
+            left={0}
+            width="100%"
+            height="100%"
+            display="flex"
+            alignItems="center"
+            justifyContent="center"
+            bgcolor="rgba(255,255,255,0.7)"
+          >
+            <ProgressSpinner />
+          </Box>
+        )}
+        {status === 'dragging' && (
+          <Box
+            position="absolute"
+            top={0}
+            left={0}
+            width="100%"
+            height="100%"
+            bgcolor="rgba(255,255,255,0.7)"
+            display="flex"
+            alignItems="center"
+            justifyContent="center"
+          >
+            <Typography>Haz clic o arrastra</Typography>
+          </Box>
+        )}
+        {status === 'error' && (
+          <Badge
+            content=""
+            color="error"
+            variant="dot"
+            sx={{ position: 'absolute', top: 4, right: 4 }}
+          >
+            <span />
+          </Badge>
+        )}
+      </Box>
+      <input
+        type="file"
+        hidden
+        ref={inputRef}
+        onChange={onInputChange}
+        accept={mimeTypes.join(',')}
+        data-testid="file-input"
+      />
+      <Snackbar
+        message={snackbar.message}
+        open={snackbar.open}
+        onClose={() => setSnackbar({ open: false, message: '' })}
+      />
+    </Box>
+  );
+}
+
+export default ImageUpload;

--- a/frontend/src/components/molecules/index.ts
+++ b/frontend/src/components/molecules/index.ts
@@ -38,3 +38,4 @@ export { FilterChip } from './FilterChip';
 export { TableRowItem } from './TableRowItem';
 export { StockLevelSlider } from './StockLevelSlider';
 export { DiscountCheckboxGroup } from './DiscountCheckboxGroup';
+export { ImageUpload } from './ImageUpload';

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,1 +1,7 @@
 import '@testing-library/jest-dom';
+
+// Polyfill createObjectURL for tests
+Object.defineProperty(global.URL, 'createObjectURL', {
+  writable: true,
+  value: jest.fn(() => 'blob:mock'),
+});


### PR DESCRIPTION
## Summary
- add ImageUpload molecule for hero/thumbnail images
- document and test the new component
- export component from molecules index
- polyfill createObjectURL for tests

## Testing
- `pnpm --filter ./frontend test`

------
https://chatgpt.com/codex/tasks/task_e_6854a4a20928832b86c8b0763c34d4c6