### PR TITLE
Add SnackbarAlert molecule

### DIFF
--- a/frontend/src/components/molecules/SnackbarAlert.docs.mdx
+++ b/frontend/src/components/molecules/SnackbarAlert.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './SnackbarAlert.stories';
+import { SnackbarAlert } from './SnackbarAlert';
+
+<Meta of={Stories} />
+
+# SnackbarAlert
+
+Molecula para mostrar retroalimentación breve tras acciones CRUD.
+
+<Story id="molecules-snackbaralert--success" />
+
+<ArgsTable of={SnackbarAlert} story="Success" />

--- a/frontend/src/components/molecules/SnackbarAlert.stories.tsx
+++ b/frontend/src/components/molecules/SnackbarAlert.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { SnackbarAlert } from './SnackbarAlert';
+
+const meta: Meta<typeof SnackbarAlert> = {
+  title: 'Molecules/SnackbarAlert',
+  component: SnackbarAlert,
+  args: {
+    open: true,
+    message: 'Cambios guardados',
+    severity: 'success',
+    sticky: false,
+  },
+  argTypes: {
+    severity: { control: 'select', options: ['success', 'info', 'warning', 'error'] },
+    open: { control: 'boolean' },
+    sticky: { control: 'boolean' },
+    onClose: { action: 'closed' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof SnackbarAlert>;
+
+export const Success: Story = {};
+
+export const Info: Story = {
+  args: { severity: 'info', message: 'Información disponible' },
+};
+
+export const Warning: Story = {
+  args: { severity: 'warning', message: 'Revisa los campos' },
+};
+
+export const Error: Story = {
+  args: { severity: 'error', message: 'Error al guardar' },
+};
+
+export const StickyDemo: Story = {
+  args: { sticky: true },
+};

--- a/frontend/src/components/molecules/SnackbarAlert.test.tsx
+++ b/frontend/src/components/molecules/SnackbarAlert.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from '../../theme';
+import { SnackbarAlert } from './SnackbarAlert';
+import React from 'react';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('SnackbarAlert', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('renders message when open', () => {
+    renderWithTheme(<SnackbarAlert open message="Hecho" />);
+    expect(screen.getByText('Hecho')).toBeInTheDocument();
+  });
+
+  it('auto hides after duration', () => {
+    const handleClose = jest.fn();
+    renderWithTheme(
+      <SnackbarAlert open message="Ok" onClose={handleClose} autoHideDuration={100} />,
+    );
+    act(() => {
+      jest.advanceTimersByTime(150);
+    });
+    expect(handleClose).toHaveBeenCalled();
+  });
+
+  it('does not auto hide when sticky', () => {
+    const handleClose = jest.fn();
+    renderWithTheme(
+      <SnackbarAlert
+        open
+        message="Stay"
+        sticky
+        onClose={handleClose}
+        autoHideDuration={100}
+      />,
+    );
+    act(() => {
+      jest.advanceTimersByTime(150);
+    });
+    expect(handleClose).not.toHaveBeenCalled();
+  });
+
+  it('calls onClose when close button clicked', async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    const handleClose = jest.fn();
+    renderWithTheme(<SnackbarAlert open message="Cerrar" onClose={handleClose} />);
+    await user.click(screen.getByRole('button', { name: /cerrar/i }));
+    act(() => {
+      jest.advanceTimersByTime(0);
+    });
+    expect(handleClose).toHaveBeenCalled();
+  });
+
+  it('does not steal focus when shown', async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    renderWithTheme(
+      <>
+        <button>focus</button>
+        <SnackbarAlert open message="Msg" />
+      </>,
+    );
+    const btn = screen.getByText('focus');
+    await user.click(btn);
+    act(() => {
+      jest.advanceTimersByTime(0);
+    });
+    expect(btn).toHaveFocus();
+  });
+});

--- a/frontend/src/components/molecules/SnackbarAlert.tsx
+++ b/frontend/src/components/molecules/SnackbarAlert.tsx
@@ -1,0 +1,52 @@
+import { ReactNode } from 'react';
+import { Snackbar, Alert, TertiaryButton } from '../atoms';
+
+export interface SnackbarAlertProps {
+  /** Controla la visibilidad del snackbar */
+  open: boolean;
+  /** Texto o nodo a mostrar */
+  message: ReactNode;
+  /** Severidad que define color e ícono */
+  severity?: 'success' | 'info' | 'warning' | 'error';
+  /** Si es verdadero, no se cierra automáticamente */
+  sticky?: boolean;
+  /** Tiempo antes de ocultarse automáticamente (ms) */
+  autoHideDuration?: number;
+  /** Callback al cerrarse */
+  onClose?: () => void;
+}
+
+/**
+ * Combina `Snackbar` y `Alert` para notificaciones breves en la parte inferior.
+ */
+export function SnackbarAlert({
+  open,
+  message,
+  severity = 'info',
+  sticky = false,
+  autoHideDuration = 4000,
+  onClose,
+}: SnackbarAlertProps) {
+  const hide = sticky ? undefined : autoHideDuration;
+
+  const action = (
+    <TertiaryButton size="small" onClick={onClose} aria-label="Cerrar">
+      Cerrar
+    </TertiaryButton>
+  );
+
+  return (
+    <Snackbar
+      open={open}
+      onClose={onClose}
+      autoHideDuration={hide}
+      message={
+        <Alert severity={severity} role="status" action={action} sx={{ width: '100%' }}>
+          {message}
+        </Alert>
+      }
+    />
+  );
+}
+
+export default SnackbarAlert;

--- a/frontend/src/components/molecules/index.ts
+++ b/frontend/src/components/molecules/index.ts
@@ -39,3 +39,4 @@ export { TableRowItem } from './TableRowItem';
 export { StockLevelSlider } from './StockLevelSlider';
 export { DiscountCheckboxGroup } from './DiscountCheckboxGroup';
 export { ImageUpload } from './ImageUpload';
+export { SnackbarAlert } from './SnackbarAlert';


### PR DESCRIPTION
## Summary
- add `SnackbarAlert` molecule for stackable snackbars with severity
- document via Storybook and MDX
- cover behaviour with RTL tests

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68557fac1884832bb78cc7204cecac37