### PR TITLE
feat(molecules): add DualDateRangeField component

### DIFF
--- a/frontend/src/components/molecules/DualDateRangeField.docs.mdx
+++ b/frontend/src/components/molecules/DualDateRangeField.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './DualDateRangeField.stories';
+import { DualDateRangeField } from './DualDateRangeField';
+
+<Meta of={Stories} />
+
+# DualDateRangeField
+
+Selector de rango de fechas con campos Inicio y Fin.
+
+<Story id="molecules-dualdaterangefield--rango-normal" />
+
+<ArgsTable of={DualDateRangeField} story="RangoNormal" />

--- a/frontend/src/components/molecules/DualDateRangeField.stories.tsx
+++ b/frontend/src/components/molecules/DualDateRangeField.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import dayjs from 'dayjs';
+import { DualDateRangeField } from './DualDateRangeField';
+
+const meta: Meta<typeof DualDateRangeField> = {
+  title: 'Molecules/DualDateRangeField',
+  component: DualDateRangeField,
+  args: {
+    start: null,
+    end: null,
+  },
+  argTypes: {
+    onChange: { action: 'changed' },
+    start: { control: 'date' },
+    end: { control: 'date' },
+    disabled: { control: 'boolean' },
+    startLabel: { control: 'text' },
+    endLabel: { control: 'text' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof DualDateRangeField>;
+
+export const RangoNormal: Story = {
+  args: {
+    start: dayjs().startOf('month'),
+    end: dayjs().startOf('month').add(7, 'day'),
+  },
+};
+
+export const FinAntesDeInicio: Story = {
+  args: {
+    start: dayjs('2025-01-10'),
+    end: dayjs('2025-01-05'),
+  },
+};
+
+export const SoloInicio: Story = {
+  args: {
+    start: dayjs(),
+    end: null,
+  },
+};

--- a/frontend/src/components/molecules/DualDateRangeField.test.tsx
+++ b/frontend/src/components/molecules/DualDateRangeField.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import dayjs from 'dayjs';
+import React from 'react';
+import { ThemeProvider } from '../../theme';
+import { DualDateRangeField, DualDateRange } from './DualDateRangeField';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+function Wrapper(
+  props: Omit<React.ComponentProps<typeof DualDateRangeField>, 'start' | 'end'>,
+) {
+  const [range, setRange] = React.useState<DualDateRange>({ start: null, end: null });
+  return (
+    <DualDateRangeField
+      start={range.start}
+      end={range.end}
+      onChange={(r) => {
+        setRange(r);
+        props.onChange?.(r);
+      }}
+      {...props}
+    />
+  );
+}
+
+describe('DualDateRangeField', () => {
+  it('renders both fields and arrow', () => {
+    renderWithTheme(<DualDateRangeField start={null} end={null} onChange={() => {}} />);
+    expect(screen.getByLabelText('Inicio')).toBeInTheDocument();
+    expect(screen.getByLabelText('Fin')).toBeInTheDocument();
+    expect(screen.getByTestId('range-separator')).toBeInTheDocument();
+  });
+
+  it('opens end picker after selecting start', async () => {
+    const user = userEvent.setup();
+    renderWithTheme(<Wrapper onChange={() => {}} />);
+    const startInput = screen.getByLabelText('Inicio');
+    await user.type(startInput, '01/05/2025');
+    fireEvent.blur(startInput);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('shows error when end is before start', () => {
+    renderWithTheme(
+      <DualDateRangeField
+        start={dayjs('2025-01-10')}
+        end={dayjs('2025-01-05')}
+        onChange={() => {}}
+      />,
+    );
+    expect(
+      screen.getAllByText('La fecha final no puede ser anterior al inicio').length,
+    ).toBeGreaterThan(0);
+    const icon = screen.getByTestId('range-separator');
+    expect(icon).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/molecules/DualDateRangeField.tsx
+++ b/frontend/src/components/molecules/DualDateRangeField.tsx
@@ -1,0 +1,102 @@
+import { Box, Typography } from '@mui/material';
+import SwapHorizIcon from '@mui/icons-material/SwapHoriz';
+import { useState, useEffect } from 'react';
+import { Dayjs } from 'dayjs';
+import { LabeledDateField } from './LabeledDateField';
+
+export interface DualDateRange {
+  /** Fecha inicial del rango */
+  start: Dayjs | null;
+  /** Fecha final del rango */
+  end: Dayjs | null;
+}
+
+export interface DualDateRangeFieldProps {
+  /** Fecha inicial seleccionada */
+  start: Dayjs | null;
+  /** Fecha final seleccionada */
+  end: Dayjs | null;
+  /** Callback ejecutado al cambiar alguna de las fechas */
+  onChange: (range: DualDateRange) => void;
+  /** Deshabilita todo el componente */
+  disabled?: boolean;
+  /** Texto de la etiqueta para la fecha inicial */
+  startLabel?: string;
+  /** Texto de la etiqueta para la fecha final */
+  endLabel?: string;
+  /** Mensaje de error mostrado cuando fin < inicio */
+  errorMessage?: string;
+}
+
+/**
+ * Selector de rango de fechas para definir vigencias.
+ * Abre autom\u00E1ticamente el selector de fin al elegir inicio
+ * y muestra error cuando la fecha final es anterior.
+ */
+export function DualDateRangeField({
+  start,
+  end,
+  onChange,
+  disabled = false,
+  startLabel = 'Inicio',
+  endLabel = 'Fin',
+  errorMessage = 'La fecha final no puede ser anterior al inicio',
+}: DualDateRangeFieldProps) {
+  const [openEnd, setOpenEnd] = useState(false);
+
+  useEffect(() => {
+    if (!start) {
+      setOpenEnd(false);
+    }
+  }, [start]);
+
+  const error = Boolean(start && end && end.isBefore(start));
+
+  const handleStartChange = (value: Dayjs | null) => {
+    onChange({ start: value, end });
+    if (value) {
+      setOpenEnd(true);
+    }
+  };
+
+  const handleEndChange = (value: Dayjs | null) => {
+    onChange({ start, end: value });
+  };
+
+  return (
+    <Box display="flex" flexDirection="column" gap={0.5}>
+      <Box display="flex" alignItems="center" gap={1}>
+        <LabeledDateField
+          label={startLabel}
+          value={start}
+          onChange={handleStartChange}
+          disabled={disabled}
+        />
+        <SwapHorizIcon
+          data-testid="range-separator"
+          color={error ? 'error' : 'disabled'}
+          fontSize="small"
+        />
+        <LabeledDateField
+          label={endLabel}
+          value={end}
+          onChange={handleEndChange}
+          disabled={disabled}
+          minDate={start ?? undefined}
+          open={openEnd}
+          onOpen={() => setOpenEnd(true)}
+          onClose={() => setOpenEnd(false)}
+          error={error}
+          helperText={error ? errorMessage : undefined}
+        />
+      </Box>
+      {error && (
+        <Typography variant="body2" color="error" sx={{ mt: 0.5 }}>
+          {errorMessage}
+        </Typography>
+      )}
+    </Box>
+  );
+}
+
+export default DualDateRangeField;

--- a/frontend/src/components/molecules/index.ts
+++ b/frontend/src/components/molecules/index.ts
@@ -40,3 +40,4 @@ export { StockLevelSlider } from './StockLevelSlider';
 export { DiscountCheckboxGroup } from './DiscountCheckboxGroup';
 export { ImageUpload } from './ImageUpload';
 export { SnackbarAlert } from './SnackbarAlert';
+export { DualDateRangeField } from './DualDateRangeField';


### PR DESCRIPTION
## Summary
- add `DualDateRangeField` molecule to pick start and end dates
- document the new component and create storybook examples
- include tests for range validation and automatic end picker
- export new molecule from index

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685589937784832b912a7be7736e5c2d