### PR TITLE
feat(ui): add StatusToggleChip molecule

### DIFF
--- a/frontend/src/components/molecules/StatusToggleChip.docs.mdx
+++ b/frontend/src/components/molecules/StatusToggleChip.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './StatusToggleChip.stories';
+import { StatusToggleChip } from './StatusToggleChip';
+
+<Meta of={Stories} />
+
+# StatusToggleChip
+
+Chip que alterna entre estados de visibilidad o activación.
+
+<Story id="molecules-statustogglechip--active" />
+
+<ArgsTable of={StatusToggleChip} story="Active" />

--- a/frontend/src/components/molecules/StatusToggleChip.stories.tsx
+++ b/frontend/src/components/molecules/StatusToggleChip.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { StatusToggleChip } from './StatusToggleChip';
+
+const meta: Meta<typeof StatusToggleChip> = {
+  title: 'Molecules/StatusToggleChip',
+  component: StatusToggleChip,
+  args: {
+    defaultActive: true,
+    loading: false,
+    disabled: false,
+    hasPermission: true,
+  },
+  argTypes: {
+    onToggle: { action: 'toggled' },
+    defaultActive: { control: 'boolean' },
+    loading: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+    hasPermission: { control: 'boolean' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof StatusToggleChip>;
+
+export const Active: Story = {};
+
+export const Inactive: Story = { args: { defaultActive: false } };
+
+export const Loading: Story = { args: { loading: true } };
+
+export const Disabled: Story = { args: { disabled: true } };
+
+export const ToggleEnVivo: Story = {
+  render: function ToggleEnVivoRender(args) {
+    const [active, setActive] = useState(args.defaultActive);
+    return (
+      <StatusToggleChip
+        {...args}
+        defaultActive={active}
+        onToggle={(next) => setActive(next)}
+      />
+    );
+  },
+  parameters: { controls: { exclude: ['onToggle'] } },
+};

--- a/frontend/src/components/molecules/StatusToggleChip.test.tsx
+++ b/frontend/src/components/molecules/StatusToggleChip.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from '../../theme';
+import { StatusToggleChip } from './StatusToggleChip';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('StatusToggleChip', () => {
+  it('shows initial active state', () => {
+    renderWithTheme(<StatusToggleChip defaultActive onToggle={() => {}} />);
+    expect(screen.getByText('Activo')).toBeInTheDocument();
+  });
+
+  it('toggles state on click and emits event', async () => {
+    const user = userEvent.setup();
+    const handle = jest.fn();
+    renderWithTheme(<StatusToggleChip defaultActive onToggle={handle} />);
+    await user.click(screen.getByRole('button'));
+    expect(handle).toHaveBeenCalledWith(false);
+    expect(screen.getByText('Archivado')).toBeInTheDocument();
+  });
+
+  it('does not toggle when disabled', async () => {
+    const user = userEvent.setup();
+    const handle = jest.fn();
+    renderWithTheme(<StatusToggleChip defaultActive disabled onToggle={handle} />);
+    const chip = screen.getByRole('button');
+    expect(chip).toHaveAttribute('aria-disabled', 'true');
+    await expect(user.click(chip)).rejects.toThrow();
+    expect(handle).not.toHaveBeenCalled();
+  });
+
+  it('shows spinner when loading', () => {
+    renderWithTheme(<StatusToggleChip loading onToggle={() => {}} />);
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+  });
+
+  it('shows lock icon without permission', () => {
+    renderWithTheme(<StatusToggleChip hasPermission={false} onToggle={() => {}} />);
+    expect(screen.getAllByLabelText('Sin permiso')[0]).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/molecules/StatusToggleChip.tsx
+++ b/frontend/src/components/molecules/StatusToggleChip.tsx
@@ -1,0 +1,88 @@
+import AutorenewIcon from '@mui/icons-material/Autorenew';
+import LockIcon from '@mui/icons-material/Lock';
+import { useState } from 'react';
+import { Chip, ChipProps, Tooltip, ProgressSpinner } from '../atoms';
+
+export interface StatusToggleChipProps
+  extends Omit<
+    ChipProps,
+    'label' | 'color' | 'onClick' | 'icon' | 'onDelete' | 'deleteIcon'
+  > {
+  /** Estado inicial del chip */
+  defaultActive?: boolean;
+  /** Manejador al cambiar de estado */
+  onToggle?: (active: boolean) => void;
+  /** Muestra indicador de carga */
+  loading?: boolean;
+  /** Deshabilita la interacción */
+  disabled?: boolean;
+  /** Controla si el usuario tiene permiso para modificar */
+  hasPermission?: boolean;
+}
+
+/**
+ * Chip que alterna entre "Activo" y "Archivado" con icono rotatorio.
+ */
+export function StatusToggleChip({
+  defaultActive = false,
+  onToggle,
+  loading = false,
+  disabled = false,
+  hasPermission = true,
+  sx,
+  ...props
+}: StatusToggleChipProps) {
+  const [active, setActive] = useState(defaultActive);
+
+  const handleToggle = () => {
+    if (disabled || loading || !hasPermission) return;
+    const next = !active;
+    setActive(next);
+    onToggle?.(next);
+  };
+
+  const label = active ? 'Activo' : 'Archivado';
+  const color: ChipProps['color'] = active ? 'success' : 'default';
+  const arrowIcon = loading ? (
+    <ProgressSpinner size={16} />
+  ) : (
+    <AutorenewIcon fontSize="small" />
+  );
+
+  const chip = (
+    <Chip
+      label={label}
+      color={color}
+      onClick={handleToggle}
+      onDelete={handleToggle}
+      deleteIcon={arrowIcon}
+      disabled={disabled || loading || !hasPermission}
+      sx={{
+        cursor: disabled || loading || !hasPermission ? 'default' : 'pointer',
+        ...sx,
+      }}
+      {...props}
+    />
+  );
+
+  if (!hasPermission) {
+    return (
+      <Tooltip title="Sin permiso">
+        <span>
+          <Chip
+            label={label}
+            color={color}
+            icon={<LockIcon fontSize="small" aria-label="Sin permiso" />}
+            disabled
+            sx={sx}
+            {...props}
+          />
+        </span>
+      </Tooltip>
+    );
+  }
+
+  return chip;
+}
+
+export default StatusToggleChip;

--- a/frontend/src/components/molecules/index.ts
+++ b/frontend/src/components/molecules/index.ts
@@ -41,3 +41,4 @@ export { DiscountCheckboxGroup } from './DiscountCheckboxGroup';
 export { ImageUpload } from './ImageUpload';
 export { SnackbarAlert } from './SnackbarAlert';
 export { DualDateRangeField } from './DualDateRangeField';
+export { StatusToggleChip } from './StatusToggleChip';


### PR DESCRIPTION
## Summary
- add `StatusToggleChip` molecule with permission lock handling
- create Storybook docs and stories
- add RTL tests
- export from molecules index

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68559b00becc832bb6eb6a355f4c38aa