### PR TITLE
feat(ui): add CurrencySummaryRow molecule

### DIFF
--- a/frontend/src/components/atoms/CurrencyField.tsx
+++ b/frontend/src/components/atoms/CurrencyField.tsx
@@ -7,6 +7,8 @@ export interface CurrencyFieldProps
   value: number | '';
   /** C\u00F3digo de moneda ISO 4217 */
   currency?: string;
+  /** Locale para formatear la moneda */
+  locale?: string;
   /** Manejador de cambio con el nuevo valor num\u00E9rico o vac\u00EDo */
   onChange: (event: ChangeEvent<HTMLInputElement>, value: number | '') => void;
 }
@@ -19,6 +21,7 @@ export function CurrencyField({
   value,
   onChange,
   currency = 'USD',
+  locale = 'en-US',
   onFocus,
   onBlur,
   inputProps,
@@ -27,7 +30,7 @@ export function CurrencyField({
   const [focused, setFocused] = useState(false);
 
   const format = (val: number) =>
-    new Intl.NumberFormat('en-US', { style: 'currency', currency }).format(val);
+    new Intl.NumberFormat(locale, { style: 'currency', currency }).format(val);
 
   const displayValue = value === '' ? '' : focused ? String(value) : format(value);
 

--- a/frontend/src/components/molecules/CurrencySummaryRow.docs.mdx
+++ b/frontend/src/components/molecules/CurrencySummaryRow.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './CurrencySummaryRow.stories';
+import { CurrencySummaryRow } from './CurrencySummaryRow';
+
+<Meta of={Stories} />
+
+# CurrencySummaryRow
+
+Muestra subtotales de una transacción con formato monetario.
+
+<Story id="molecules-currencysummaryrow--compra-estandar" />
+
+<ArgsTable of={CurrencySummaryRow} story="CompraEstandar" />

--- a/frontend/src/components/molecules/CurrencySummaryRow.stories.tsx
+++ b/frontend/src/components/molecules/CurrencySummaryRow.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { CurrencySummaryRow } from './CurrencySummaryRow';
+
+const meta: Meta<typeof CurrencySummaryRow> = {
+  title: 'Molecules/CurrencySummaryRow',
+  component: CurrencySummaryRow,
+  args: {
+    subtotal: 100,
+    taxes: 19,
+    currency: 'USD',
+    locale: 'en-US',
+  },
+  argTypes: {
+    subtotal: { control: 'number' },
+    taxes: { control: 'number' },
+    currency: { control: 'text' },
+    locale: { control: 'text' },
+    loading: { control: 'boolean' },
+    onCreditNoteClick: { action: 'credit' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof CurrencySummaryRow>;
+
+export const CompraEstandar: Story = {};
+
+export const DevolucionNegativa: Story = {
+  args: { subtotal: -50, taxes: -9.5 },
+};
+
+export const Cargando: Story = {
+  args: { loading: true },
+};

--- a/frontend/src/components/molecules/CurrencySummaryRow.test.tsx
+++ b/frontend/src/components/molecules/CurrencySummaryRow.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider } from '../../theme';
+import { CurrencySummaryRow } from './CurrencySummaryRow';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('CurrencySummaryRow', () => {
+  it('calculates total and formats value', () => {
+    renderWithTheme(
+      <CurrencySummaryRow subtotal={80} taxes={20} currency="USD" locale="en-US" />,
+    );
+    const totalInput = screen.getByLabelText('Total') as HTMLInputElement;
+    expect(totalInput.value).toBe(
+      new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(
+        100,
+      ),
+    );
+  });
+
+  it('updates format when locale changes', () => {
+    const { rerender } = renderWithTheme(
+      <CurrencySummaryRow subtotal={80} taxes={20} currency="USD" locale="es-CO" />,
+    );
+    let totalInput = screen.getByLabelText('Total') as HTMLInputElement;
+    expect(totalInput.value).toBe(
+      new Intl.NumberFormat('es-CO', { style: 'currency', currency: 'USD' }).format(
+        100,
+      ),
+    );
+    rerender(
+      <ThemeProvider>
+        <CurrencySummaryRow subtotal={80} taxes={20} currency="USD" locale="en-US" />
+      </ThemeProvider>,
+    );
+    totalInput = screen.getByLabelText('Total') as HTMLInputElement;
+    expect(totalInput.value).toBe(
+      new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(
+        100,
+      ),
+    );
+  });
+
+  it('shows badge only when total is negative', () => {
+    const { rerender } = renderWithTheme(
+      <CurrencySummaryRow subtotal={-50} taxes={-5} />,
+    );
+    expect(screen.getByText('Nota de crédito')).toBeInTheDocument();
+    rerender(
+      <ThemeProvider>
+        <CurrencySummaryRow subtotal={50} taxes={5} />
+      </ThemeProvider>,
+    );
+    expect(screen.queryByText('Nota de crédito')).toBeNull();
+  });
+
+  it('renders skeletons when loading', () => {
+    renderWithTheme(<CurrencySummaryRow subtotal={0} taxes={0} loading />);
+    expect(screen.getByTestId('subtotal-skeleton')).toBeInTheDocument();
+    expect(screen.getByTestId('taxes-skeleton')).toBeInTheDocument();
+    expect(screen.getByTestId('total-skeleton')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/molecules/CurrencySummaryRow.tsx
+++ b/frontend/src/components/molecules/CurrencySummaryRow.tsx
@@ -1,0 +1,98 @@
+import { Box, Skeleton } from '@mui/material';
+import { LabeledCurrencyField } from './LabeledCurrencyField';
+import { Badge } from '../atoms';
+
+export interface CurrencySummaryRowProps {
+  /** Subtotal sin impuestos */
+  subtotal: number;
+  /** Valor de impuestos */
+  taxes: number;
+  /** Código de moneda ISO 4217 */
+  currency?: string;
+  /** Locale actual para formatear */
+  locale?: string;
+  /** Muestra esqueletos de carga */
+  loading?: boolean;
+  /** Callback al hacer clic en la badge negativa */
+  onCreditNoteClick?: () => void;
+}
+
+/**
+ * Muestra tres campos de moneda alineados a la derecha con el resumen de una transacción.
+ */
+export function CurrencySummaryRow({
+  subtotal,
+  taxes,
+  currency = 'USD',
+  locale = 'en-US',
+  loading = false,
+  onCreditNoteClick,
+}: CurrencySummaryRowProps) {
+  const total = subtotal + taxes;
+
+  if (loading) {
+    return (
+      <Box display="flex" justifyContent="flex-end" gap={2} alignItems="center">
+        <Skeleton
+          variant="rectangular"
+          width={120}
+          height={56}
+          data-testid="subtotal-skeleton"
+        />
+        <Skeleton
+          variant="rectangular"
+          width={120}
+          height={56}
+          data-testid="taxes-skeleton"
+        />
+        <Skeleton
+          variant="rectangular"
+          width={120}
+          height={56}
+          data-testid="total-skeleton"
+        />
+      </Box>
+    );
+  }
+
+  return (
+    <Box display="flex" justifyContent="flex-end" gap={2} alignItems="center">
+      <LabeledCurrencyField
+        label="Subtotal"
+        value={subtotal}
+        onChange={() => {}}
+        currency={currency}
+        locale={locale}
+        inputProps={{ readOnly: true }}
+      />
+      <LabeledCurrencyField
+        label="Impuestos"
+        value={taxes}
+        onChange={() => {}}
+        currency={currency}
+        locale={locale}
+        inputProps={{ readOnly: true }}
+      />
+      <Box display="flex" alignItems="center" gap={1}>
+        <LabeledCurrencyField
+          label="Total"
+          value={total}
+          onChange={() => {}}
+          currency={currency}
+          locale={locale}
+          inputProps={{ readOnly: true }}
+        />
+        {total < 0 && (
+          <Badge
+            content="Nota de crédito"
+            color="warning"
+            onClick={onCreditNoteClick}
+            sx={{ cursor: onCreditNoteClick ? 'pointer' : 'default' }}
+          />
+        )}
+      </Box>
+    </Box>
+  );
+}
+
+export default CurrencySummaryRow;

--- a/frontend/src/components/molecules/LabeledCurrencyField.tsx
+++ b/frontend/src/components/molecules/LabeledCurrencyField.tsx
@@ -17,6 +17,7 @@ export function LabeledCurrencyField({
   value,
   onChange,
   currency = 'USD',
+  locale = 'en-US',
   min,
   max,
   error = false,
@@ -62,6 +63,7 @@ export function LabeledCurrencyField({
         value={value}
         onChange={onChange}
         currency={currency}
+        locale={locale}
         min={min}
         max={max}
         error={error || outOfRange}

--- a/frontend/src/components/molecules/index.ts
+++ b/frontend/src/components/molecules/index.ts
@@ -42,3 +42,4 @@ export { ImageUpload } from './ImageUpload';
 export { SnackbarAlert } from './SnackbarAlert';
 export { DualDateRangeField } from './DualDateRangeField';
 export { StatusToggleChip } from './StatusToggleChip';
+export { CurrencySummaryRow } from './CurrencySummaryRow';


### PR DESCRIPTION
## Summary
- add locale prop to CurrencyField
- pass locale through LabeledCurrencyField
- create CurrencySummaryRow molecule with badge and skeleton states
- document and test new component

## Testing
- `pnpm install`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6855a0c48b2c832ba05f5dc621b5eda4