### PR TITLE
Add ColorSwatchSelector molecule

### DIFF
--- a/frontend/src/components/molecules/ColorSwatchSelector.docs.mdx
+++ b/frontend/src/components/molecules/ColorSwatchSelector.docs.mdx
@@ -1,0 +1,16 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './ColorSwatchSelector.stories';
+import { ColorSwatchSelector } from './ColorSwatchSelector';
+
+<Meta of={Stories} />
+
+# ColorSwatchSelector
+
+Molecula para elegir un color oficial evitando duplicados.
+
+<ArgsTable of={ColorSwatchSelector} />
+
+<Story id="molecules-colorswatchselector--sin-seleccion" />
+<Story id="molecules-colorswatchselector--seleccionado" />
+<Story id="molecules-colorswatchselector--color-duplicado" />
+<Story id="molecules-colorswatchselector--solo-lectura" />

--- a/frontend/src/components/molecules/ColorSwatchSelector.stories.tsx
+++ b/frontend/src/components/molecules/ColorSwatchSelector.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ColorSwatchSelector, ColorSwatch } from './ColorSwatchSelector';
+
+const swatches: ColorSwatch[] = [
+  { code: '#ff0000', name: 'Pantone Rojo' },
+  { code: '#00ff00', name: 'Pantone Verde' },
+  { code: '#0000ff', name: 'Pantone Azul' },
+];
+
+const meta: Meta<typeof ColorSwatchSelector> = {
+  title: 'Molecules/ColorSwatchSelector',
+  component: ColorSwatchSelector,
+  args: {
+    swatches,
+    value: undefined,
+    usedColors: [],
+    readOnly: false,
+  },
+  argTypes: {
+    value: {
+      control: 'select',
+      options: swatches.map((s) => s.code).concat(undefined),
+    },
+    usedColors: { control: 'object' },
+    readOnly: { control: 'boolean' },
+    onChange: { action: 'change' },
+    onDuplicate: { action: 'duplicate' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof ColorSwatchSelector>;
+
+export const SinSeleccion: Story = {};
+export const Seleccionado: Story = { args: { value: '#ff0000' } };
+export const ColorDuplicado: Story = {
+  args: { usedColors: ['#00ff00'], value: '#00ff00' },
+};
+export const SoloLectura: Story = { args: { readOnly: true, value: '#0000ff' } };

--- a/frontend/src/components/molecules/ColorSwatchSelector.test.tsx
+++ b/frontend/src/components/molecules/ColorSwatchSelector.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from '../../theme';
+import { ColorSwatchSelector, ColorSwatch } from './ColorSwatchSelector';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+const swatches: ColorSwatch[] = [
+  { code: '#ff0000', name: 'Pantone Rojo' },
+  { code: '#00ff00', name: 'Pantone Verde' },
+];
+
+describe('ColorSwatchSelector', () => {
+  it('selects color on click', async () => {
+    const user = userEvent.setup();
+    const handle = jest.fn();
+    renderWithTheme(<ColorSwatchSelector swatches={swatches} onChange={handle} />);
+    await user.click(screen.getByRole('button', { name: 'Pantone Verde' }));
+    expect(handle).toHaveBeenCalledWith('#00ff00');
+  });
+
+  it('selects color with space key', async () => {
+    const user = userEvent.setup();
+    const handle = jest.fn();
+    renderWithTheme(<ColorSwatchSelector swatches={swatches} onChange={handle} />);
+    const btn = screen.getByRole('button', { name: 'Pantone Rojo' });
+    btn.focus();
+    await user.keyboard('[Space]');
+    expect(handle).toHaveBeenCalledWith('#ff0000');
+  });
+
+  it('triggers duplicate callback', async () => {
+    const user = userEvent.setup();
+    const dup = jest.fn();
+    renderWithTheme(
+      <ColorSwatchSelector
+        swatches={swatches}
+        usedColors={['#00ff00']}
+        onDuplicate={dup}
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: 'Pantone Verde' }));
+    expect(dup).toHaveBeenCalledWith('#00ff00');
+  });
+});

--- a/frontend/src/components/molecules/ColorSwatchSelector.tsx
+++ b/frontend/src/components/molecules/ColorSwatchSelector.tsx
@@ -1,0 +1,103 @@
+import { Box } from '@mui/material';
+import { Badge, Tooltip } from '../atoms';
+
+export interface ColorSwatch {
+  /** Código hexadecimal del color */
+  code: string;
+  /** Nombre Pantone para tooltip y accesibilidad */
+  name: string;
+}
+
+export interface ColorSwatchSelectorProps {
+  /** Lista de colores disponibles */
+  swatches: ColorSwatch[];
+  /** Código seleccionado actualmente */
+  value?: string;
+  /** Colores ya usados para validar duplicados */
+  usedColors?: string[];
+  /** Deshabilita la interacción */
+  readOnly?: boolean;
+  /** Callback al seleccionar un color válido */
+  onChange?: (code: string) => void;
+  /** Callback al intentar seleccionar un duplicado */
+  onDuplicate?: (code: string) => void;
+}
+
+/**
+ * Permite elegir un color oficial mostrando swatches circulares.
+ * Muestra error si el color está repetido en la colección.
+ */
+export function ColorSwatchSelector({
+  swatches,
+  value,
+  usedColors = [],
+  readOnly = false,
+  onChange,
+  onDuplicate,
+}: ColorSwatchSelectorProps) {
+  const handleSelect = (code: string, duplicate: boolean) => {
+    if (readOnly) return;
+    if (duplicate) {
+      onDuplicate?.(code);
+      return;
+    }
+    onChange?.(code);
+  };
+
+  return (
+    <Box display="flex" gap={1}>
+      {swatches.map((sw) => {
+        const selected = value === sw.code;
+        const duplicate = usedColors.includes(sw.code);
+        const circle = (
+          <Box
+            component="button"
+            type="button"
+            onClick={() => handleSelect(sw.code, duplicate)}
+            onKeyDown={(e) => {
+              if (e.key === ' ') {
+                e.preventDefault();
+                handleSelect(sw.code, duplicate);
+              }
+            }}
+            disabled={readOnly}
+            aria-label={sw.name}
+            tabIndex={readOnly ? -1 : 0}
+            sx={{
+              width: 28,
+              height: 28,
+              borderRadius: '50%',
+              bgcolor: sw.code,
+              border: 0,
+              padding: 0,
+              cursor: readOnly ? 'default' : 'pointer',
+              outline: selected ? '2px solid' : 'none',
+              outlineColor: selected ? 'primary.main' : undefined,
+            }}
+          />
+        );
+
+        const content = duplicate ? (
+          <Badge
+            content="x"
+            color="error"
+            overlap="circular"
+            sx={{ '& .MuiBadge-badge': { fontSize: 10, top: 0, right: 0 } }}
+          >
+            {circle}
+          </Badge>
+        ) : (
+          circle
+        );
+
+        return (
+          <Tooltip key={sw.code} title={sw.name}>
+            <span>{content}</span>
+          </Tooltip>
+        );
+      })}
+    </Box>
+  );
+}
+
+export default ColorSwatchSelector;

--- a/frontend/src/components/molecules/index.ts
+++ b/frontend/src/components/molecules/index.ts
@@ -43,3 +43,4 @@ export { SnackbarAlert } from './SnackbarAlert';
 export { DualDateRangeField } from './DualDateRangeField';
 export { StatusToggleChip } from './StatusToggleChip';
 export { CurrencySummaryRow } from './CurrencySummaryRow';
+export { ColorSwatchSelector } from './ColorSwatchSelector';


### PR DESCRIPTION
## Summary
- implement `ColorSwatchSelector` molecule for choosing official colors
- document the component in Storybook
- add interactive stories and tests
- export the new component from the molecules index

## Testing
- `npm run lint`
- `npm test`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_6855a4ba53c4832b84dad04b8fe8c7a7