### PR TITLE
feat(ui): add ProductCardGrid organism

### DIFF
--- a/frontend/src/components/organisms/ProductCardGrid.docs.mdx
+++ b/frontend/src/components/organisms/ProductCardGrid.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './ProductCardGrid.stories';
+import { ProductCardGrid } from './ProductCardGrid';
+
+<Meta of={Stories} />
+
+# ProductCardGrid
+
+Organismo que muestra un mosaico responsive de productos con badges de estado y ajuste rápido de precio.
+
+<Story id="organisms-productcardgrid--default" />
+
+<ArgsTable of={ProductCardGrid} story="Default" />

--- a/frontend/src/components/organisms/ProductCardGrid.stories.tsx
+++ b/frontend/src/components/organisms/ProductCardGrid.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ProductCardGrid, ProductCard } from './ProductCardGrid';
+
+const sampleProducts: ProductCard[] = Array.from({ length: 8 }).map((_, i) => ({
+  id: String(i + 1),
+  name: `Producto ${i + 1}`,
+  price: 10 + i,
+  status: i % 3 === 0 ? 'out_of_stock' : i % 3 === 1 ? 'promotion' : 'available',
+  src: 'https://placehold.co/40',
+}));
+
+const meta: Meta<typeof ProductCardGrid> = {
+  title: 'Organisms/ProductCardGrid',
+  component: ProductCardGrid,
+  args: {
+    products: sampleProducts,
+  },
+  argTypes: {
+    onPriceChange: { action: 'price changed' },
+    onSelect: { action: 'selected' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof ProductCardGrid>;
+
+export const Default: Story = {};
+
+export const MobileTwoColumns: Story = {
+  parameters: { viewport: { defaultViewport: 'mobile1' } },
+};
+
+export const OutOfStock: Story = {
+  args: {
+    products: [
+      {
+        id: '1',
+        name: 'Agotado',
+        price: 20,
+        status: 'out_of_stock',
+        src: 'https://placehold.co/40',
+      },
+    ],
+  },
+};

--- a/frontend/src/components/organisms/ProductCardGrid.test.tsx
+++ b/frontend/src/components/organisms/ProductCardGrid.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { ThemeProvider } from '../../theme';
+import { ProductCardGrid, ProductCard } from './ProductCardGrid';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('ProductCardGrid', () => {
+  const product: ProductCard = {
+    id: '1',
+    name: 'Producto',
+    price: 10,
+    status: 'available',
+    src: 'img.png',
+  };
+
+  it('renders product names', () => {
+    renderWithTheme(<ProductCardGrid products={[product]} />);
+    expect(screen.getByText('Producto')).toBeInTheDocument();
+  });
+
+  it('fires onSelect when pressing Enter', async () => {
+    const user = userEvent.setup();
+    const handle = jest.fn();
+    renderWithTheme(<ProductCardGrid products={[product]} onSelect={handle} />);
+    const card = screen.getAllByRole('button')[0];
+    await user.keyboard('{Enter}');
+    expect(handle).toHaveBeenCalledWith('1');
+  });
+
+  it('calls onPriceChange from stepper', async () => {
+    const user = userEvent.setup();
+    const handle = jest.fn();
+    renderWithTheme(<ProductCardGrid products={[product]} onPriceChange={handle} />);
+    const inc = screen.getByRole('button', { name: /incrementar/i });
+    await user.click(inc);
+    expect(handle).toHaveBeenCalledWith('1', 10.01);
+  });
+});

--- a/frontend/src/components/organisms/ProductCardGrid.tsx
+++ b/frontend/src/components/organisms/ProductCardGrid.tsx
@@ -1,0 +1,106 @@
+import { Box } from '@mui/material';
+import { ProductListItem, PriceStepper, StatusBadgeDisplay } from '../molecules';
+
+export interface ProductCard {
+  id: string;
+  name: string;
+  price: number;
+  status?: 'available' | 'out_of_stock' | 'promotion';
+  currency?: string;
+  src?: string;
+}
+
+export interface ProductCardGridProps {
+  /** Lista de productos a mostrar */
+  products: ProductCard[];
+  /** Callback cuando se modifica el precio */
+  onPriceChange?: (id: string, price: number) => void;
+  /** Callback al seleccionar un producto */
+  onSelect?: (id: string) => void;
+}
+
+const BADGE_MAP = {
+  available: { label: undefined, status: 'success' },
+  out_of_stock: { label: 'Sin stock', status: 'error' },
+  promotion: { label: 'En promo', status: 'warning' },
+} as const;
+
+/**
+ * Mosaico responsive de tarjetas de producto con ajuste rápido de precio.
+ */
+export function ProductCardGrid({
+  products,
+  onPriceChange,
+  onSelect,
+}: ProductCardGridProps) {
+  return (
+    <Box
+      display="grid"
+      gap={1}
+      sx={{
+        gridTemplateColumns: {
+          xs: 'repeat(2, 1fr)',
+          sm: 'repeat(3, 1fr)',
+          md: 'repeat(4, 1fr)',
+          lg: 'repeat(5, 1fr)',
+          xl: 'repeat(6, 1fr)',
+        },
+      }}
+    >
+      {products.map((p) => {
+        const badge = BADGE_MAP[p.status ?? 'available'];
+        return (
+          <Box
+            key={p.id}
+            component="button"
+            type="button"
+            onClick={() => onSelect?.(p.id)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                onSelect?.(p.id);
+              }
+            }}
+            tabIndex={0}
+            position="relative"
+            textAlign="left"
+            sx={{
+              cursor: 'pointer',
+              p: 1,
+              borderRadius: 1,
+              bgcolor:
+                p.status === 'out_of_stock'
+                  ? 'action.disabledBackground'
+                  : 'background.paper',
+              '&:hover': { bgcolor: 'action.hover' },
+            }}
+          >
+            <Box position="absolute" top={4} right={4}>
+              <StatusBadgeDisplay
+                label={badge.label}
+                status={badge.status}
+                size="small"
+              />
+            </Box>
+            <ProductListItem
+              name={p.name}
+              price={p.price}
+              status={p.status}
+              currency={p.currency}
+              src={p.src}
+            />
+            <Box position="absolute" bottom={4} left={4}>
+              <PriceStepper
+                value={p.price}
+                onChange={(val) => onPriceChange?.(p.id, val)}
+                size="small"
+              />
+            </Box>
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}
+
+export default ProductCardGrid;

--- a/frontend/src/components/organisms/index.ts
+++ b/frontend/src/components/organisms/index.ts
@@ -1,0 +1,1 @@
+export { ProductCardGrid } from './ProductCardGrid';

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -1,2 +1,3 @@
 export * from './components/atoms';
 export * from './components/molecules';
+export * from './components/organisms';


### PR DESCRIPTION
## Summary
- implement `ProductCardGrid` organism and stories/docs/tests
- export organisms from component index

## Testing
- `npm --prefix frontend run lint` *(fails: ESLint config missing)*
- `npm --prefix frontend run test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855c4dce4a0832bbc47c0d4d19bda8e