### PR TITLE
feat(ui): enhance product grid layout and stepper

### DIFF
--- a/frontend/src/components/molecules/NumberStepper.tsx
+++ b/frontend/src/components/molecules/NumberStepper.tsx
@@ -1,6 +1,8 @@
 import AddIcon from '@mui/icons-material/Add';
 import RemoveIcon from '@mui/icons-material/Remove';
 import { Box } from '@mui/material';
+import { keyframes } from '@emotion/react';
+import { useRef, useEffect, useState } from 'react';
 import { IconButton, NumberInput, NumberInputProps } from '../atoms';
 
 export interface NumberStepperProps extends Pick<NumberInputProps, 'size'> {
@@ -36,6 +38,22 @@ export function NumberStepper({
   disabled = false,
   size = 'medium',
 }: NumberStepperProps) {
+  const [animate, setAnimate] = useState(false);
+
+  useEffect(() => {
+    if (!disabled) {
+      setAnimate(true);
+      const t = setTimeout(() => setAnimate(false), 200);
+      return () => clearTimeout(t);
+    }
+    return () => {};
+  }, [value, disabled]);
+
+  const bounce = keyframes`
+    0% { transform: scale(1); }
+    50% { transform: scale(1.15); }
+    100% { transform: scale(1); }
+  `;
   const handleInputChange: NumberInputProps['onChange'] = (_, val) => {
     if (val === '') return;
     onChange(clamp(val, min, max));
@@ -66,14 +84,59 @@ export function NumberStepper({
   const disableDec = disabled || (min !== undefined && value <= min);
   const disableInc = disabled || (max !== undefined && value >= max);
 
+  const timer = useRef<NodeJS.Timeout>();
+  const delay = useRef(500);
+  const action = useRef<() => void>();
+
+  const stepHold = () => {
+    action.current?.();
+    delay.current = Math.max(50, delay.current * 0.75);
+    timer.current = setTimeout(stepHold, delay.current);
+  };
+
+  const startHold = (fn: () => void) => {
+    if (disabled) return;
+    action.current = fn;
+    fn();
+    delay.current = 500;
+    timer.current = setTimeout(stepHold, delay.current);
+  };
+
+  const stopHold = () => {
+    if (timer.current) clearTimeout(timer.current);
+    action.current = undefined;
+  };
+
   return (
     <Box display="flex" alignItems="center" gap={1}>
       <IconButton
         aria-label="decrement"
         icon={<RemoveIcon />}
         onClick={decrement}
+        onMouseDown={() => startHold(decrement)}
+        onMouseUp={stopHold}
+        onMouseLeave={stopHold}
+        onTouchStart={() => startHold(decrement)}
+        onTouchEnd={stopHold}
         disabled={disableDec}
         size={size}
+        sx={{
+          width: 32,
+          height: 32,
+          touchAction: 'none',
+          '@media (pointer: coarse)': {
+            width: 44,
+            height: 44,
+          },
+          borderRadius: '50%',
+          border: '1px solid #DDD',
+          color: '#333',
+          opacity: disableDec ? 0.4 : 1,
+          cursor: disableDec ? 'not-allowed' : 'pointer',
+          '&:hover:not(:disabled), &:focus-visible': {
+            boxShadow: '0 0 0 2px #FF7900',
+          },
+        }}
       />
       <NumberInput
         value={value}
@@ -84,15 +147,45 @@ export function NumberStepper({
         max={max}
         size={size}
         fullWidth={false}
-        inputProps={{ 'aria-label': 'current value', style: { textAlign: 'center' } }}
-        sx={{ width: size === 'small' ? 72 : 96 }}
+        inputProps={{ 'aria-label': 'current value' }}
+        sx={{
+          width: size === 'small' ? 72 : 96,
+          animation: animate ? `${bounce} 200ms ease` : undefined,
+          '& .MuiInputBase-input': {
+            textAlign: 'center',
+            fontWeight: 600,
+            fontSize: 16,
+          },
+        }}
       />
       <IconButton
         aria-label="increment"
         icon={<AddIcon />}
         onClick={increment}
+        onMouseDown={() => startHold(increment)}
+        onMouseUp={stopHold}
+        onMouseLeave={stopHold}
+        onTouchStart={() => startHold(increment)}
+        onTouchEnd={stopHold}
         disabled={disableInc}
         size={size}
+        sx={{
+          width: 32,
+          height: 32,
+          touchAction: 'none',
+          '@media (pointer: coarse)': {
+            width: 44,
+            height: 44,
+          },
+          borderRadius: '50%',
+          border: '1px solid #DDD',
+          color: '#333',
+          opacity: disableInc ? 0.4 : 1,
+          cursor: disableInc ? 'not-allowed' : 'pointer',
+          '&:hover:not(:disabled), &:focus-visible': {
+            boxShadow: '0 0 0 2px #FF7900',
+          },
+        }}
       />
     </Box>
   );

--- a/frontend/src/components/organisms/ProductCardGrid.tsx
+++ b/frontend/src/components/organisms/ProductCardGrid.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react';
 import { Box, Typography, Skeleton } from '@mui/material';
-import { Avatar, Chip } from '../atoms';
+import ImageIcon from '@mui/icons-material/Image';
+import { keyframes } from '@emotion/react';
+import { Chip } from '../atoms';
 import { NumberStepper } from '../molecules';
 
 export interface ProductCard {
@@ -30,6 +32,11 @@ const BADGE_MAP = {
   default: { label: undefined, color: 'default' },
 } as const;
 
+const pulse = keyframes`
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.9; }
+`;
+
 /**
  * Mosaico responsive de tarjetas de producto con estado y acción de agregado.
  */
@@ -53,7 +60,8 @@ export function ProductCardGrid({
         columnGap: 2,
         gridTemplateColumns: {
           xs: '1fr',
-          sm: 'repeat(auto-fill, minmax(240px, 1fr))',
+          sm: 'repeat(auto-fill, minmax(280px, 1fr))',
+          md: 'repeat(auto-fill, minmax(220px, 1fr))',
         },
       }}
       p={2}
@@ -95,18 +103,21 @@ export function ProductCardGrid({
             position="relative"
             sx={{
               display: 'flex',
-              flexDirection: 'column',
-              gap: 1,
+              flexDirection: { xs: 'column', sm: 'row' },
               bgcolor: '#FFFAF0',
               borderRadius: 1,
-              p: 2,
-              minHeight: 140,
+              overflow: 'hidden',
               cursor: 'pointer',
+              boxShadow: 1,
               transition: 'box-shadow .15s',
-              '&:hover': { boxShadow: '0 2px 8px rgba(0,0,0,.12)' },
-              '&:focus-visible': { boxShadow: '0 2px 8px rgba(0,0,0,.12)' },
-              opacity: isOut ? 0.45 : 1,
-              pointerEvents: isOut ? 'none' : 'auto',
+              '&:hover': {
+                boxShadow: '0 4px 12px rgba(0,0,0,.15)',
+              },
+              '&:hover .product-img': {
+                transform: 'scale(1.02)',
+              },
+              '&:focus-visible': { boxShadow: '0 4px 12px rgba(0,0,0,.15)' },
+              opacity: isOut ? 0.7 : 1,
             }}
             onClick={() => onSelect?.(product!.id)}
             onKeyDown={(e) => {
@@ -116,44 +127,116 @@ export function ProductCardGrid({
               }
             }}
           >
-            <Avatar
-              variant="square"
-              alt={product!.name}
-              src={product!.src}
-              sx={{ width: { xs: 56, sm: 40 }, height: { xs: 56, sm: 40 } }}
-            />
-            <Box display="flex" flexDirection="column" gap={1}>
-              <Typography
-                variant="body1"
-                fontWeight={500}
-                sx={{ color: '#2E2E2E' }}
-                noWrap
-              >
-                {product!.name}
-              </Typography>
-              <Box display="flex" alignItems="center" gap={1}>
-                <Typography variant="body2" sx={{ color: '#2E2E2E' }}>
-                  {formattedPrice}
-                </Typography>
-                <NumberStepper
-                  value={qtyMap[product!.id] ?? 0}
-                  onChange={(val) => {
-                    setQtyMap((m) => ({ ...m, [product!.id]: val }));
-                    onChange?.(product!.id, val);
+            <Box
+              sx={{
+                flexBasis: { sm: '60%' },
+                position: 'relative',
+                width: { xs: '100%', sm: undefined },
+                aspectRatio: '9 / 16',
+                overflow: 'hidden',
+              }}
+            >
+              {product!.src ? (
+                <Box
+                  component="img"
+                  src={product!.src}
+                  alt={product!.name}
+                  className="product-img"
+                  sx={{
+                    position: { xs: 'absolute', sm: 'relative' },
+                    top: 0,
+                    left: 0,
+                    width: '100%',
+                    height: '100%',
+                    objectFit: 'cover',
+                    transition: 'transform 120ms ease-out',
+                    filter: isOut ? 'grayscale(50%)' : undefined,
                   }}
-                  min={0}
+                />
+              ) : (
+                <Box
+                  position="absolute"
+                  top={0}
+                  left={0}
+                  width="100%"
+                  height="100%"
+                  display="flex"
+                  alignItems="center"
+                  justifyContent="center"
+                  sx={{ bgcolor: '#eee' }}
+                >
+                  <ImageIcon sx={{ fontSize: 40, color: '#aaa' }} />
+                </Box>
+              )}
+              <Box
+                sx={{
+                  position: 'absolute',
+                  top: 0,
+                  right: 0,
+                  bottom: 0,
+                  width: 24,
+                  background: 'linear-gradient(to right, rgba(255,255,255,0), #FFFAF0)',
+                }}
+              />
+            </Box>
+            <Box
+              sx={{
+                flexBasis: { sm: '40%' },
+                p: 2,
+                position: 'relative',
+                display: 'flex',
+                flexDirection: 'column',
+                justifyContent: 'center',
+                gap: 1,
+              }}
+            >
+              <Box position="absolute" top={8} right={8}>
+                <Chip
+                  label={badge.label}
+                  color={badge.color}
                   size="small"
-                  disabled={isOut}
+                  sx={{
+                    fontWeight: 700,
+                    fontSize: 12,
+                    animation:
+                      product!.status === 'promotion'
+                        ? `${pulse} 4s infinite`
+                        : undefined,
+                  }}
+                  role="status"
+                  aria-live="polite"
                 />
               </Box>
-            </Box>
-            <Box position="absolute" top={8} right={12}>
-              <Chip
-                label={badge.label}
-                color={badge.color}
+              <Typography
+                variant="body1"
+                fontWeight={600}
+                sx={{ color: '#333', mt: 0.5, overflow: 'hidden' }}
+                component="div"
+              >
+                <Box
+                  component="span"
+                  sx={{
+                    display: '-webkit-box',
+                    WebkitBoxOrient: 'vertical',
+                    WebkitLineClamp: 2,
+                    overflow: 'hidden',
+                  }}
+                >
+                  {product!.name}
+                </Box>
+              </Typography>
+              <Typography variant="h6" sx={{ color: '#333', fontWeight: 700, mb: 1 }}>
+                {formattedPrice}
+              </Typography>
+              <NumberStepper
+                value={qtyMap[product!.id] ?? 0}
+                onChange={(val) => {
+                  setQtyMap((m) => ({ ...m, [product!.id]: val }));
+                  onChange?.(product!.id, val);
+                }}
+                min={0}
                 size="small"
-                role="status"
-                aria-live="polite"
+                disabled={isOut}
               />
             </Box>
           </Box>


### PR DESCRIPTION
## Summary
- improve NumberStepper with hold-to-accelerate, focus ring and bounce animation
- redesign ProductCardGrid with two-column layout, fading image and pulsing badge

## Testing
- `pnpm --filter ./frontend lint`
- `pnpm --filter ./frontend test`

------
https://chatgpt.com/codex/tasks/task_e_685856841380832b8bdb4bc51febf5d5