### PR TITLE
feat(organisms): add ProductDetailHeader organism

### DIFF
--- a/frontend/src/components/organisms/ProductDetailHeader.docs.mdx
+++ b/frontend/src/components/organisms/ProductDetailHeader.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './ProductDetailHeader.stories';
+import { ProductDetailHeader } from './ProductDetailHeader';
+
+<Meta of={Stories} />
+
+# ProductDetailHeader
+
+Cabecera “hero” que muestra la imagen y nombre de un SKU con controles de estado.
+
+<Story id="organisms-productdetailheader--activo" />
+
+<ArgsTable of={ProductDetailHeader} story="Activo" />

--- a/frontend/src/components/organisms/ProductDetailHeader.stories.tsx
+++ b/frontend/src/components/organisms/ProductDetailHeader.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { rest } from 'msw';
+import { ProductDetailHeader } from './ProductDetailHeader';
+
+const meta: Meta<typeof ProductDetailHeader> = {
+  title: 'Organisms/ProductDetailHeader',
+  component: ProductDetailHeader,
+  parameters: {
+    msw: {
+      handlers: [
+        rest.patch('/api/v1/products/1', (_req, res, ctx) => res(ctx.status(200))),
+      ],
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof ProductDetailHeader>;
+
+export const Activo: Story = {
+  args: {
+    name: 'Producto Demo',
+    src: 'https://placehold.co/200',
+    defaultActive: true,
+    onStatusChange: async () => {},
+    onNameSave: async () => {},
+  },
+};
+
+export const Archivado: Story = {
+  args: {
+    name: 'Producto Demo',
+    src: 'https://placehold.co/200',
+    defaultActive: false,
+  },
+};
+
+export const ErrorGuardando: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        rest.patch('/api/v1/products/1', (_req, res, ctx) => res(ctx.status(500))),
+      ],
+    },
+  },
+  args: {
+    name: 'Producto Demo',
+    src: 'https://placehold.co/200',
+    defaultActive: true,
+    onStatusChange: async () => {
+      throw new Error('Error');
+    },
+  },
+};

--- a/frontend/src/components/organisms/ProductDetailHeader.test.tsx
+++ b/frontend/src/components/organisms/ProductDetailHeader.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { ThemeProvider } from '../../theme';
+import { ProductDetailHeader } from './ProductDetailHeader';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('ProductDetailHeader', () => {
+  it('toggles status successfully', async () => {
+    const user = userEvent.setup();
+    const handle = jest.fn().mockResolvedValue(undefined);
+    renderWithTheme(<ProductDetailHeader name="Prod" onStatusChange={handle} />);
+    await user.click(screen.getByRole('button', { name: /activo/i }));
+    await waitFor(() => expect(handle).toHaveBeenCalled());
+  });
+
+  it('shows error when toggle fails', async () => {
+    const user = userEvent.setup();
+    const handle = jest.fn().mockRejectedValue(new Error('fail'));
+    renderWithTheme(<ProductDetailHeader name="Prod" onStatusChange={handle} />);
+    await user.click(screen.getByRole('button', { name: /activo/i }));
+    expect(await screen.findByText('Error al guardar')).toBeInTheDocument();
+  });
+
+  it('opens modal to edit name', async () => {
+    const user = userEvent.setup();
+    const handle = jest.fn().mockResolvedValue(undefined);
+    renderWithTheme(<ProductDetailHeader name="Prod" onNameSave={handle} />);
+    await user.click(screen.getByRole('button', { name: /editar nombre/i }));
+    await user.type(screen.getByRole('textbox'), 'X');
+    await user.click(screen.getByRole('button', { name: /guardar/i }));
+    await waitFor(() => expect(handle).toHaveBeenCalledWith('ProdX'));
+  });
+});

--- a/frontend/src/components/organisms/ProductDetailHeader.tsx
+++ b/frontend/src/components/organisms/ProductDetailHeader.tsx
@@ -1,0 +1,136 @@
+import { useState } from 'react';
+import EditIcon from '@mui/icons-material/Edit';
+import { Box, Dialog, DialogContent, TextField, Typography } from '@mui/material';
+import {
+  AvatarName,
+  IconLabelButton,
+  ModalFooter,
+  ModalHeader,
+  StatusToggleChip,
+} from '../molecules';
+
+export interface ProductDetailHeaderProps {
+  /** Nombre del SKU */
+  name: string;
+  /** Imagen del producto */
+  src?: string;
+  /** Estado inicial */
+  defaultActive?: boolean;
+  /** Callback al guardar un nuevo nombre */
+  onNameSave?: (name: string) => Promise<void> | void;
+  /** Callback al cambiar de estado */
+  onStatusChange?: (active: boolean) => Promise<void> | void;
+}
+
+/**
+ * Cabecera hero con avatar grande y controles de estado/edición.
+ */
+export function ProductDetailHeader({
+  name: initialName,
+  src,
+  defaultActive = true,
+  onNameSave,
+  onStatusChange,
+}: ProductDetailHeaderProps) {
+  const [name, setName] = useState(initialName);
+  const [editOpen, setEditOpen] = useState(false);
+  const [input, setInput] = useState(initialName);
+  const [saving, setSaving] = useState(false);
+  const [active, setActive] = useState(defaultActive);
+  const [statusLoading, setStatusLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [announce, setAnnounce] = useState('');
+
+  const handleStatusToggle = async (next: boolean) => {
+    setStatusLoading(true);
+    setError(null);
+    try {
+      await onStatusChange?.(next);
+      setActive(next);
+      setAnnounce('Guardado con éxito');
+    } catch (e) {
+      setError('Error al guardar');
+    } finally {
+      setStatusLoading(false);
+    }
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      await onNameSave?.(input);
+      setName(input);
+      setAnnounce('Guardado con éxito');
+      setEditOpen(false);
+    } catch (e) {
+      setError('Error al guardar');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Box display="flex" alignItems="center" gap={2}>
+      <Box
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            setEditOpen(true);
+          }
+        }}
+      >
+        <AvatarName
+          name={name}
+          src={src}
+          orientation="vertical"
+          sx={{
+            width: 200,
+            height: 200,
+            '& .MuiAvatar-root': { width: 200, height: 200 },
+          }}
+        />
+      </Box>
+      <Box display="flex" flexDirection="column" gap={1} alignItems="flex-start">
+        <StatusToggleChip
+          defaultActive={active}
+          loading={statusLoading}
+          onToggle={handleStatusToggle}
+        />
+        <IconLabelButton
+          icon={<EditIcon />}
+          label="Editar nombre"
+          onClick={() => setEditOpen(true)}
+        />
+        <Box role="status" aria-live="polite" sx={{ fontSize: 0 }}>
+          {announce}
+        </Box>
+        {error && (
+          <Typography color="error" variant="body2">
+            {error}
+          </Typography>
+        )}
+      </Box>
+      <Dialog open={editOpen} onClose={() => setEditOpen(false)}>
+        <ModalHeader title="Editar nombre" onClose={() => setEditOpen(false)} />
+        <DialogContent>
+          <TextField
+            fullWidth
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            autoFocus
+          />
+        </DialogContent>
+        <ModalFooter
+          primaryText="Guardar"
+          onPrimary={handleSave}
+          primaryDisabled={saving || input.trim() === ''}
+          secondaryText="Cancelar"
+          onSecondary={() => setEditOpen(false)}
+          loading={saving}
+        />
+      </Dialog>
+    </Box>
+  );
+}
+
+export default ProductDetailHeader;

--- a/frontend/src/components/organisms/index.ts
+++ b/frontend/src/components/organisms/index.ts
@@ -1,1 +1,2 @@
 export { ProductCardGrid } from './ProductCardGrid';
+export { ProductDetailHeader } from './ProductDetailHeader';


### PR DESCRIPTION
## Summary
- implement `ProductDetailHeader` organism with edit modal and toggle chip
- document component with Storybook stories and MDX
- add unit tests

## Testing
- `npx --yes pnpm -r --if-present lint`
- `npx --yes pnpm -r --if-present test`


------
https://chatgpt.com/codex/tasks/task_e_6859c330e89c832bb8b0febfababd516