### PR TITLE
feat(products): enhance product header usability

### DIFF
--- a/frontend/src/components/molecules/ModalFooter.stories.tsx
+++ b/frontend/src/components/molecules/ModalFooter.stories.tsx
@@ -14,6 +14,7 @@ const meta: Meta<typeof ModalFooter> = {
     primaryDisabled: { control: 'boolean' },
     loading: { control: 'boolean' },
     align: { control: 'radio', options: ['right', 'center'] },
+    primaryType: { control: 'radio', options: ['button', 'submit'] },
     onPrimary: { action: 'primary' },
     onSecondary: { action: 'secondary' },
   },

--- a/frontend/src/components/molecules/ModalFooter.test.tsx
+++ b/frontend/src/components/molecules/ModalFooter.test.tsx
@@ -61,4 +61,12 @@ describe('ModalFooter', () => {
     btn.click();
     expect(onPrimary).not.toHaveBeenCalled();
   });
+
+  it('sets button type when primaryType provided', () => {
+    renderWithTheme(
+      <ModalFooter primaryText="Ok" onPrimary={() => {}} primaryType="submit" />,
+    );
+    const btn = screen.getByRole('button', { name: /ok/i });
+    expect(btn).toHaveAttribute('type', 'submit');
+  });
 });

--- a/frontend/src/components/molecules/ModalFooter.tsx
+++ b/frontend/src/components/molecules/ModalFooter.tsx
@@ -17,6 +17,8 @@ export interface ModalFooterProps {
   loading?: boolean;
   /** Alineación de los botones */
   align?: 'right' | 'center';
+  /** Tipo de boton primario */
+  primaryType?: 'button' | 'submit';
 }
 
 /**
@@ -30,6 +32,7 @@ export function ModalFooter({
   primaryDisabled = false,
   loading = false,
   align = 'right',
+  primaryType = 'button',
 }: ModalFooterProps) {
   const justifyContent = align === 'center' ? 'center' : 'flex-end';
 
@@ -38,7 +41,12 @@ export function ModalFooter({
       {secondaryText && onSecondary && (
         <SecondaryButton onClick={onSecondary}>{secondaryText}</SecondaryButton>
       )}
-      <PrimaryButton onClick={onPrimary} disabled={primaryDisabled} loading={loading}>
+      <PrimaryButton
+        type={primaryType}
+        onClick={onPrimary}
+        disabled={primaryDisabled}
+        loading={loading}
+      >
         {primaryText}
       </PrimaryButton>
     </Box>

--- a/frontend/src/components/organisms/ProductDetailHeader.stories.tsx
+++ b/frontend/src/components/organisms/ProductDetailHeader.stories.tsx
@@ -21,9 +21,16 @@ export const Activo: Story = {
   args: {
     name: 'Producto Demo',
     src: 'https://placehold.co/200',
+    sku: 'SKU-001',
     defaultActive: true,
+    breadcrumbs: [
+      { label: 'Inicio', href: '/' },
+      { label: 'Productos', href: '/products' },
+      { label: 'Detalle' },
+    ],
     onStatusChange: async () => {},
     onNameSave: async () => {},
+    onImageChange: async () => {},
   },
 };
 
@@ -31,6 +38,7 @@ export const Archivado: Story = {
   args: {
     name: 'Producto Demo',
     src: 'https://placehold.co/200',
+    sku: 'SKU-001',
     defaultActive: false,
   },
 };
@@ -46,9 +54,18 @@ export const ErrorGuardando: Story = {
   args: {
     name: 'Producto Demo',
     src: 'https://placehold.co/200',
+    sku: 'SKU-001',
     defaultActive: true,
     onStatusChange: async () => {
       throw new Error('Error');
     },
+    onImageChange: async () => {},
+  },
+};
+
+export const Cargando: Story = {
+  args: {
+    name: 'Producto Demo',
+    loading: true,
   },
 };

--- a/frontend/src/components/organisms/ProductDetailHeader.test.tsx
+++ b/frontend/src/components/organisms/ProductDetailHeader.test.tsx
@@ -22,7 +22,16 @@ describe('ProductDetailHeader', () => {
     const handle = jest.fn().mockRejectedValue(new Error('fail'));
     renderWithTheme(<ProductDetailHeader name="Prod" onStatusChange={handle} />);
     await user.click(screen.getByRole('button', { name: /activo/i }));
-    expect(await screen.findByText('Error al guardar')).toBeInTheDocument();
+    expect((await screen.findAllByText('Error al guardar')).length).toBeGreaterThan(0);
+  });
+
+  it('focusable avatar opens dialog with enter', async () => {
+    const user = userEvent.setup();
+    renderWithTheme(<ProductDetailHeader name="Prod" />);
+    const box = screen.getAllByRole('button')[0];
+    box.focus();
+    await user.keyboard('[Enter]');
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
   });
 
   it('opens modal to edit name', async () => {
@@ -31,7 +40,7 @@ describe('ProductDetailHeader', () => {
     renderWithTheme(<ProductDetailHeader name="Prod" onNameSave={handle} />);
     await user.click(screen.getByRole('button', { name: /editar nombre/i }));
     await user.type(screen.getByRole('textbox'), 'X');
-    await user.click(screen.getByRole('button', { name: /guardar/i }));
+    await user.keyboard('[Enter]');
     await waitFor(() => expect(handle).toHaveBeenCalledWith('ProdX'));
   });
 });


### PR DESCRIPTION
## Summary
- make ModalFooter accept HTML button type
- show breadcrumbs, SKU and responsive avatar in ProductDetailHeader
- allow editing name with Enter key
- integrate ImageUpload and Snackbar feedback
- document and test new behaviours

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6859ea195398832bb2d23e464a8615d6