### PR TITLE
feat(product): improve ProductDetailHeader image edit

### DIFF
--- a/frontend/src/components/molecules/ImageUpload.docs.mdx
+++ b/frontend/src/components/molecules/ImageUpload.docs.mdx
@@ -9,5 +9,6 @@ import { ImageUpload } from './ImageUpload';
 Componente para subir la foto hero o miniaturas de looks.
 
 <Story id="molecules-imageupload--vacío" />
+<Story id="molecules-imageupload--boton" />
 
 <ArgsTable of={ImageUpload} />

--- a/frontend/src/components/molecules/ImageUpload.stories.tsx
+++ b/frontend/src/components/molecules/ImageUpload.stories.tsx
@@ -37,3 +37,10 @@ export const FormatoInválido: Story = {
     uploadFn: () => Promise.reject(new Error('Formato inválido')),
   },
 };
+
+export const Boton: Story = {
+  args: {
+    variant: 'icon',
+    size: 40,
+  },
+};

--- a/frontend/src/components/molecules/ImageUpload.test.tsx
+++ b/frontend/src/components/molecules/ImageUpload.test.tsx
@@ -37,4 +37,13 @@ describe('ImageUpload', () => {
     await userEvent.upload(input, file);
     expect(mockUpload).not.toHaveBeenCalled();
   });
+
+  it('permite subir usando la variante icono', async () => {
+    const mockUpload = jest.fn(async () => 'https://cdn.test/img.png');
+    renderWithTheme(<ImageUpload variant="icon" uploadFn={mockUpload} />);
+    const file = new File(['foto'], 'foto.png', { type: 'image/png' });
+    const input = screen.getByTestId('file-input') as HTMLInputElement;
+    await userEvent.upload(input, file);
+    await waitFor(() => expect(mockUpload).toHaveBeenCalled());
+  });
 });

--- a/frontend/src/components/molecules/ImageUpload.tsx
+++ b/frontend/src/components/molecules/ImageUpload.tsx
@@ -14,6 +14,12 @@ export interface ImageUploadProps {
   mimeTypes?: string[];
   /** Callback cuando la carga finaliza exitosamente */
   onChange?: (url: string) => void;
+  /** Variante de visualización */
+  variant?: 'dropzone' | 'icon';
+  /** Dimensión del contenedor */
+  size?: number;
+  /** Muestra vista previa cuando existe una imagen */
+  showPreview?: boolean;
 }
 
 type Status = 'idle' | 'dragging' | 'uploading' | 'success' | 'error';
@@ -24,10 +30,15 @@ export function ImageUpload({
   maxSize = 5 * 1024 * 1024,
   mimeTypes = ['image/jpeg', 'image/png'],
   onChange,
+  variant = 'dropzone',
+  size = 128,
+  showPreview = true,
 }: ImageUploadProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const [status, setStatus] = useState<Status>('idle');
-  const [preview, setPreview] = useState<string | undefined>(value);
+  const [preview, setPreview] = useState<string | undefined>(
+    showPreview ? value : undefined,
+  );
   const [snackbar, setSnackbar] = useState<{ open: boolean; message: string }>({
     open: false,
     message: '',
@@ -69,6 +80,7 @@ export function ImageUpload({
     handleFiles(e.target.files);
   };
 
+  const dimension = size;
   const borderColor =
     status === 'dragging'
       ? 'info.main'
@@ -77,81 +89,100 @@ export function ImageUpload({
         : 'grey.400';
 
   return (
-    <Box position="relative" width={128} height={128}>
-      <Box
-        component="div"
-        onClick={openFile}
-        onDragOver={(e) => {
-          e.preventDefault();
-          setStatus('dragging');
-        }}
-        onDragLeave={resetDrag}
-        onDrop={onDrop}
-        sx={{
-          width: 128,
-          height: 128,
-          border: '2px dashed',
-          borderColor,
-          borderRadius: 1,
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          overflow: 'hidden',
-          position: 'relative',
-          cursor: 'pointer',
-          bgcolor: 'grey.100',
-        }}
-        data-testid="dropzone"
-        data-error={status === 'error'}
-      >
-        {preview ? (
-          <Avatar src={preview} variant="rounded" sx={{ width: 128, height: 128 }} />
-        ) : (
-          <Avatar sx={{ width: 128, height: 128, bgcolor: 'grey.300' }}>
-            <CloudUploadIcon fontSize="large" />
-          </Avatar>
-        )}
-        {status === 'uploading' && (
-          <Box
-            position="absolute"
-            top={0}
-            left={0}
-            width="100%"
-            height="100%"
-            display="flex"
-            alignItems="center"
-            justifyContent="center"
-            bgcolor="rgba(255,255,255,0.7)"
-          >
-            <ProgressSpinner />
-          </Box>
-        )}
-        {status === 'dragging' && (
-          <Box
-            position="absolute"
-            top={0}
-            left={0}
-            width="100%"
-            height="100%"
-            bgcolor="rgba(255,255,255,0.7)"
-            display="flex"
-            alignItems="center"
-            justifyContent="center"
-          >
-            <Typography>Haz clic o arrastra</Typography>
-          </Box>
-        )}
-        {status === 'error' && (
-          <Badge
-            content=""
-            color="error"
-            variant="dot"
-            sx={{ position: 'absolute', top: 4, right: 4 }}
-          >
-            <span />
-          </Badge>
-        )}
-      </Box>
+    <Box position="relative" width={dimension} height={dimension}>
+      {variant === 'dropzone' ? (
+        <Box
+          component="div"
+          onClick={openFile}
+          onDragOver={(e) => {
+            e.preventDefault();
+            setStatus('dragging');
+          }}
+          onDragLeave={resetDrag}
+          onDrop={onDrop}
+          sx={{
+            width: dimension,
+            height: dimension,
+            border: '2px dashed',
+            borderColor,
+            borderRadius: 1,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            overflow: 'hidden',
+            position: 'relative',
+            cursor: 'pointer',
+            bgcolor: 'grey.100',
+          }}
+          data-testid="dropzone"
+          data-error={status === 'error'}
+        >
+          {showPreview && preview ? (
+            <Avatar src={preview} variant="rounded" sx={{ width: dimension, height: dimension }} />
+          ) : (
+            <Avatar sx={{ width: dimension, height: dimension, bgcolor: 'grey.300' }}>
+              <CloudUploadIcon fontSize="large" />
+            </Avatar>
+          )}
+          {status === 'uploading' && (
+            <Box
+              position="absolute"
+              top={0}
+              left={0}
+              width="100%"
+              height="100%"
+              display="flex"
+              alignItems="center"
+              justifyContent="center"
+              bgcolor="rgba(255,255,255,0.7)"
+            >
+              <ProgressSpinner />
+            </Box>
+          )}
+          {status === 'dragging' && (
+            <Box
+              position="absolute"
+              top={0}
+              left={0}
+              width="100%"
+              height="100%"
+              bgcolor="rgba(255,255,255,0.7)"
+              display="flex"
+              alignItems="center"
+              justifyContent="center"
+            >
+              <Typography>Haz clic o arrastra</Typography>
+            </Box>
+          )}
+          {status === 'error' && (
+            <Badge
+              content=""
+              color="error"
+              variant="dot"
+              sx={{ position: 'absolute', top: 4, right: 4 }}
+            >
+              <span />
+            </Badge>
+          )}
+        </Box>
+      ) : (
+        <Box
+          onClick={openFile}
+          sx={{
+            width: dimension,
+            height: dimension,
+            borderRadius: '50%',
+            bgcolor: 'grey.200',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            cursor: 'pointer',
+          }}
+          data-testid="upload-button"
+        >
+          {status === 'uploading' ? <ProgressSpinner size={20} /> : <CloudUploadIcon />}
+        </Box>
+      )}
       <input
         type="file"
         hidden

--- a/frontend/src/components/organisms/ProductDetailHeader.tsx
+++ b/frontend/src/components/organisms/ProductDetailHeader.tsx
@@ -112,6 +112,7 @@ export function ProductDetailHeader({
             setEditOpen(true);
           }
         }}
+        sx={{ position: 'relative' }}
       >
         {loading ? (
           <Skeleton
@@ -135,8 +136,13 @@ export function ProductDetailHeader({
           />
         )}
         {onImageChange && !loading && (
-          <Box mt={1}>
-            <ImageUpload value={src} onChange={onImageChange} />
+          <Box position="absolute" bottom={8} right={8}>
+            <ImageUpload
+              variant="icon"
+              size={40}
+              showPreview={false}
+              onChange={onImageChange}
+            />
           </Box>
         )}
       </Box>


### PR DESCRIPTION
## Summary
- add `variant`, `size` and `showPreview` props to `ImageUpload`
- overlay compact upload button inside `ProductDetailHeader`
- showcase new `ImageUpload` variant in Storybook docs
- cover `ImageUpload` icon variant with test

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685a101b9ea8832bb30a7ba79c167091