### PR TITLE
feat(atoms): enhanced avatar and button states

### DIFF
--- a/frontend/src/components/atoms/Avatar.docs.mdx
+++ b/frontend/src/components/atoms/Avatar.docs.mdx
@@ -10,4 +10,8 @@ Muestra la imagen de perfil o iniciales de un usuario.
 
 <Story id="atoms-avatar--image" />
 
+## Con estado
+
+<Story id="atoms-avatar--with-status" />
+
 <ArgsTable of={Avatar} story="Image" />

--- a/frontend/src/components/atoms/Avatar.stories.tsx
+++ b/frontend/src/components/atoms/Avatar.stories.tsx
@@ -8,12 +8,17 @@ const meta: Meta<typeof Avatar> = {
     src: 'https://i.pravatar.cc/40',
     alt: 'Foto de usuario',
     size: 'medium',
+    status: undefined,
   },
   argTypes: {
     src: { control: 'text' },
     alt: { control: 'text' },
     variant: { control: 'select', options: ['circular', 'rounded', 'square'] },
     size: { control: 'select', options: ['small', 'medium', 'large'] },
+    status: {
+      control: 'select',
+      options: [undefined, 'online', 'offline', 'busy', 'away'],
+    },
   },
 };
 export default meta;
@@ -32,4 +37,8 @@ export const Rounded: Story = {
 
 export const Large: Story = {
   args: { size: 'large' },
+};
+
+export const WithStatus: Story = {
+  args: { status: 'online' },
 };

--- a/frontend/src/components/atoms/Avatar.test.tsx
+++ b/frontend/src/components/atoms/Avatar.test.tsx
@@ -29,4 +29,9 @@ describe('Avatar', () => {
     const root = getByText('JP');
     expect(root).toHaveStyle({ width: '64px', height: '64px' });
   });
+
+  it('shows status badge when status is provided', () => {
+    renderWithTheme(<Avatar status="online">JP</Avatar>);
+    expect(screen.getByTestId('avatar-status')).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/atoms/Avatar.tsx
+++ b/frontend/src/components/atoms/Avatar.tsx
@@ -1,4 +1,6 @@
 import MuiAvatar, { AvatarProps as MuiAvatarProps } from '@mui/material/Avatar';
+import Badge from '@mui/material/Badge';
+import { useTheme } from '@mui/material/styles';
 
 const SIZE_MAP = {
   small: 32,
@@ -9,16 +11,47 @@ const SIZE_MAP = {
 export interface AvatarProps extends MuiAvatarProps {
   /** Tamaño predefinido del avatar. */
   size?: keyof typeof SIZE_MAP;
+  /** Estado del usuario que muestra un indicador de color. */
+  status?: 'online' | 'offline' | 'busy' | 'away';
 }
 
 /**
  * Muestra la imagen o iniciales de un usuario en forma circular por defecto.
  */
-export function Avatar({ size, sx, ...props }: AvatarProps) {
+export function Avatar({ size, status, sx, ...props }: AvatarProps) {
+  const theme = useTheme();
   const dimension = size ? SIZE_MAP[size] : undefined;
   const sxProp = dimension ? { width: dimension, height: dimension, ...sx } : sx;
+  const avatar = <MuiAvatar sx={sxProp} {...props} />;
 
-  return <MuiAvatar sx={sxProp} {...props} />;
+  if (!status) {
+    return avatar;
+  }
+
+  const colorMap = {
+    online: theme.palette.success.main,
+    offline: theme.palette.grey[500],
+    busy: theme.palette.error.main,
+    away: theme.palette.warning.main,
+  } as const;
+
+  return (
+    <Badge
+      data-testid="avatar-status"
+      overlap="circular"
+      anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+      variant="dot"
+      sx={{
+        '& .MuiBadge-badge': {
+          backgroundColor: colorMap[status],
+          color: colorMap[status],
+          boxShadow: `0 0 0 2px ${theme.palette.background.paper}`,
+        },
+      }}
+    >
+      {avatar}
+    </Badge>
+  );
 }
 
 export default Avatar;

--- a/frontend/src/components/atoms/SecondaryButton.docs.mdx
+++ b/frontend/src/components/atoms/SecondaryButton.docs.mdx
@@ -10,4 +10,8 @@ Botón para acciones secundarias, utiliza la variante `outlined` y color `second
 
 <Story id="atoms-secondarybutton--default" />
 
+## Con carga
+
+<Story id="atoms-secondarybutton--loading" />
+
 <ArgsTable of={SecondaryButton} story="Default" />

--- a/frontend/src/components/atoms/SecondaryButton.stories.tsx
+++ b/frontend/src/components/atoms/SecondaryButton.stories.tsx
@@ -8,6 +8,7 @@ const meta: Meta<typeof SecondaryButton> = {
   component: SecondaryButton,
   args: {
     children: 'Secondary action',
+    loading: false,
   },
   argTypes: {
     onClick: { action: 'clicked' },
@@ -15,6 +16,12 @@ const meta: Meta<typeof SecondaryButton> = {
     endIcon: { control: false },
     children: { control: 'text' },
     disabled: { control: 'boolean' },
+    loading: { control: 'boolean' },
+    loadingPosition: {
+      control: 'select',
+      options: ['center', 'start', 'end'],
+    },
+    loadingText: { control: 'text' },
   },
 };
 export default meta;
@@ -32,4 +39,16 @@ export const WithIcons: Story = {
     startIcon: <SaveIcon />,
     endIcon: <DeleteIcon />,
   },
+};
+
+export const Loading: Story = {
+  args: { loading: true },
+};
+
+export const LoadingStart: Story = {
+  args: { loading: true, loadingPosition: 'start' },
+};
+
+export const LoadingWithText: Story = {
+  args: { loading: true, loadingText: 'Saving...' },
 };

--- a/frontend/src/components/atoms/SecondaryButton.test.tsx
+++ b/frontend/src/components/atoms/SecondaryButton.test.tsx
@@ -24,4 +24,9 @@ describe('SecondaryButton', () => {
     btn.click();
     expect(handleClick).not.toHaveBeenCalled();
   });
+
+  it('shows spinner when loading', () => {
+    renderWithTheme(<SecondaryButton loading>Load</SecondaryButton>);
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/atoms/SecondaryButton.tsx
+++ b/frontend/src/components/atoms/SecondaryButton.tsx
@@ -1,7 +1,15 @@
+import { Box, CircularProgress } from '@mui/material';
 import { Button as MuiButton, ButtonProps as MuiButtonProps } from '@mui/material';
-import { PropsWithChildren } from 'react';
+import { PropsWithChildren, ReactNode } from 'react';
 
-export type SecondaryButtonProps = MuiButtonProps & PropsWithChildren;
+export interface SecondaryButtonProps extends MuiButtonProps, PropsWithChildren {
+  /** Activa un spinner y deshabilita el botón. */
+  loading?: boolean;
+  /** Posición del spinner. */
+  loadingPosition?: 'start' | 'end' | 'center';
+  /** Texto a mostrar cuando está cargando. */
+  loadingText?: ReactNode;
+}
 
 /**
  * Botón secundario para acciones alternativas.
@@ -13,19 +21,37 @@ export function SecondaryButton({
   disabled = false,
   startIcon,
   endIcon,
+  loading = false,
+  loadingPosition = 'center',
+  loadingText,
   ...props
 }: PropsWithChildren<SecondaryButtonProps>) {
+  const spinner = <CircularProgress size={20} color="inherit" />;
+  const content = loading && loadingText ? loadingText : children;
+
   return (
     <MuiButton
       variant="outlined"
       color="secondary"
       onClick={onClick}
-      disabled={disabled}
-      startIcon={startIcon}
-      endIcon={endIcon}
+      disabled={disabled || loading}
+      startIcon={loading && loadingPosition === 'start' ? spinner : startIcon}
+      endIcon={loading && loadingPosition === 'end' ? spinner : endIcon}
+      aria-busy={loading || undefined}
       {...props}
     >
-      {children}
+      {loading && loadingPosition === 'center' ? (
+        <>
+          {spinner}
+          {loadingText && (
+            <Box component="span" sx={{ ml: 1 }}>
+              {loadingText}
+            </Box>
+          )}
+        </>
+      ) : (
+        content
+      )}
     </MuiButton>
   );
 }

--- a/frontend/src/components/atoms/TertiaryButton.docs.mdx
+++ b/frontend/src/components/atoms/TertiaryButton.docs.mdx
@@ -10,4 +10,8 @@ Botón para acciones de bajo énfasis o enlaces estilo botón.
 
 <Story id="atoms-tertiarybutton--default" />
 
+## Con carga
+
+<Story id="atoms-tertiarybutton--loading" />
+
 <ArgsTable of={TertiaryButton} story="Default" />

--- a/frontend/src/components/atoms/TertiaryButton.stories.tsx
+++ b/frontend/src/components/atoms/TertiaryButton.stories.tsx
@@ -7,6 +7,7 @@ const meta: Meta<typeof TertiaryButton> = {
   component: TertiaryButton,
   args: {
     children: 'Tertiary action',
+    loading: false,
   },
   argTypes: {
     onClick: { action: 'clicked' },
@@ -15,6 +16,12 @@ const meta: Meta<typeof TertiaryButton> = {
     children: { control: 'text' },
     disabled: { control: 'boolean' },
     href: { control: 'text' },
+    loading: { control: 'boolean' },
+    loadingPosition: {
+      control: 'select',
+      options: ['center', 'start', 'end'],
+    },
+    loadingText: { control: 'text' },
   },
 };
 export default meta;
@@ -29,4 +36,16 @@ export const Disabled: Story = {
 
 export const WithIcon: Story = {
   args: { endIcon: <ArrowForwardIcon /> },
+};
+
+export const Loading: Story = {
+  args: { loading: true },
+};
+
+export const LoadingStart: Story = {
+  args: { loading: true, loadingPosition: 'start' },
+};
+
+export const LoadingWithText: Story = {
+  args: { loading: true, loadingText: 'Loading...' },
 };

--- a/frontend/src/components/atoms/TertiaryButton.test.tsx
+++ b/frontend/src/components/atoms/TertiaryButton.test.tsx
@@ -39,4 +39,9 @@ describe('TertiaryButton', () => {
     const link = screen.getByRole('link', { name: /link/i });
     expect(link).toHaveAttribute('href', 'https://example.com');
   });
+
+  it('shows spinner when loading', () => {
+    renderWithTheme(<TertiaryButton loading>Send</TertiaryButton>);
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/atoms/TertiaryButton.tsx
+++ b/frontend/src/components/atoms/TertiaryButton.tsx
@@ -1,7 +1,15 @@
+import { Box, CircularProgress } from '@mui/material';
 import { Button as MuiButton, ButtonProps as MuiButtonProps } from '@mui/material';
-import { PropsWithChildren } from 'react';
+import { PropsWithChildren, ReactNode } from 'react';
 
-export type TertiaryButtonProps = MuiButtonProps & PropsWithChildren;
+export interface TertiaryButtonProps extends MuiButtonProps, PropsWithChildren {
+  /** Muestra un spinner y deshabilita el botón. */
+  loading?: boolean;
+  /** Posición del spinner. */
+  loadingPosition?: 'start' | 'end' | 'center';
+  /** Texto a mostrar durante la carga. */
+  loadingText?: ReactNode;
+}
 
 /**
  * Botón terciario para acciones de bajo énfasis o enlaces estilo botón.
@@ -13,16 +21,23 @@ export function TertiaryButton({
   disabled = false,
   startIcon,
   endIcon,
+  loading = false,
+  loadingPosition = 'center',
+  loadingText,
   ...props
 }: PropsWithChildren<TertiaryButtonProps>) {
+  const spinner = <CircularProgress size={20} color="inherit" />;
+  const content = loading && loadingText ? loadingText : children;
+
   return (
     <MuiButton
       variant="text"
       color="primary"
       onClick={onClick}
-      disabled={disabled}
-      startIcon={startIcon}
-      endIcon={endIcon}
+      disabled={disabled || loading}
+      startIcon={loading && loadingPosition === 'start' ? spinner : startIcon}
+      endIcon={loading && loadingPosition === 'end' ? spinner : endIcon}
+      aria-busy={loading || undefined}
       sx={{
         textTransform: 'none',
         '&:hover': {
@@ -32,7 +47,18 @@ export function TertiaryButton({
       }}
       {...props}
     >
-      {children}
+      {loading && loadingPosition === 'center' ? (
+        <>
+          {spinner}
+          {loadingText && (
+            <Box component="span" sx={{ ml: 1 }}>
+              {loadingText}
+            </Box>
+          )}
+        </>
+      ) : (
+        content
+      )}
     </MuiButton>
   );
 }


### PR DESCRIPTION
## Summary
- add user status indicator to `Avatar`
- add loading states to `SecondaryButton`
- add loading states to `TertiaryButton`
- document new props and extend stories for the affected atoms
- update unit tests

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config file)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685c0b1d1804832b9bd7ca59ee12a099