### PR TITLE
feat(ui): add loading state to secondary and tertiary buttons

### DIFF
--- a/frontend/src/components/atoms/PrimaryButton.docs.mdx
+++ b/frontend/src/components/atoms/PrimaryButton.docs.mdx
@@ -1,0 +1,13 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import * as Stories from './PrimaryButton.stories';
+import { PrimaryButton } from './PrimaryButton';
+
+<Meta of={Stories} />
+
+# PrimaryButton
+
+Botón principal que destaca la acción clave en cada vista. Admite estados de carga y muestra un spinner opcional.
+
+<Story id="atoms-primarybutton--default" />
+
+<ArgsTable of={PrimaryButton} story="Default" />

--- a/frontend/src/components/atoms/SecondaryButton.docs.mdx
+++ b/frontend/src/components/atoms/SecondaryButton.docs.mdx
@@ -6,7 +6,7 @@ import { SecondaryButton } from './SecondaryButton';
 
 # SecondaryButton
 
-Botón para acciones secundarias, utiliza la variante `outlined` y color `secondary` de MUI.
+Botón para acciones secundarias, utiliza la variante `outlined` y color `secondary` de MUI. Permite un estado de carga opcional.
 
 <Story id="atoms-secondarybutton--default" />
 

--- a/frontend/src/components/atoms/SecondaryButton.stories.tsx
+++ b/frontend/src/components/atoms/SecondaryButton.stories.tsx
@@ -15,6 +15,12 @@ const meta: Meta<typeof SecondaryButton> = {
     endIcon: { control: false },
     children: { control: 'text' },
     disabled: { control: 'boolean' },
+    loading: { control: 'boolean' },
+    loadingPosition: {
+      control: 'select',
+      options: ['center', 'start', 'end'],
+    },
+    loadingText: { control: 'text' },
   },
 };
 export default meta;
@@ -32,4 +38,12 @@ export const WithIcons: Story = {
     startIcon: <SaveIcon />,
     endIcon: <DeleteIcon />,
   },
+};
+
+export const Loading: Story = {
+  args: { loading: true },
+};
+
+export const LoadingWithText: Story = {
+  args: { loading: true, loadingText: 'Saving...' },
 };

--- a/frontend/src/components/atoms/SecondaryButton.test.tsx
+++ b/frontend/src/components/atoms/SecondaryButton.test.tsx
@@ -24,4 +24,11 @@ describe('SecondaryButton', () => {
     btn.click();
     expect(handleClick).not.toHaveBeenCalled();
   });
+
+  it('shows spinner and disables when loading', () => {
+    renderWithTheme(<SecondaryButton loading>Wait</SecondaryButton>);
+    const btn = screen.getByRole('button');
+    expect(btn).toBeDisabled();
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/atoms/SecondaryButton.tsx
+++ b/frontend/src/components/atoms/SecondaryButton.tsx
@@ -1,7 +1,25 @@
-import { Button as MuiButton, ButtonProps as MuiButtonProps } from '@mui/material';
-import { PropsWithChildren } from 'react';
+import {
+  Box,
+  CircularProgress,
+  Button as MuiButton,
+  ButtonProps as MuiButtonProps,
+} from '@mui/material';
+import { PropsWithChildren, ReactNode } from 'react';
 
-export type SecondaryButtonProps = MuiButtonProps & PropsWithChildren;
+export interface SecondaryButtonProps extends MuiButtonProps {
+  /**
+   * Muestra un spinner e impide interacción mientras se completa la acción.
+   */
+  loading?: boolean;
+  /**
+   * Posición del spinner cuando `loading` es true.
+   */
+  loadingPosition?: 'start' | 'end' | 'center';
+  /**
+   * Texto opcional cuando el botón está cargando. Si se omite, se mantiene el contenido original.
+   */
+  loadingText?: ReactNode;
+}
 
 /**
  * Botón secundario para acciones alternativas.
@@ -13,19 +31,37 @@ export function SecondaryButton({
   disabled = false,
   startIcon,
   endIcon,
+  loading = false,
+  loadingPosition = 'center',
+  loadingText,
   ...props
 }: PropsWithChildren<SecondaryButtonProps>) {
+  const spinner = <CircularProgress size={20} color="inherit" />;
+  const content = loading && loadingText ? loadingText : children;
+
   return (
     <MuiButton
       variant="outlined"
       color="secondary"
       onClick={onClick}
-      disabled={disabled}
-      startIcon={startIcon}
-      endIcon={endIcon}
+      disabled={disabled || loading}
+      aria-busy={loading || undefined}
+      startIcon={loading && loadingPosition === 'start' ? spinner : startIcon}
+      endIcon={loading && loadingPosition === 'end' ? spinner : endIcon}
       {...props}
     >
-      {children}
+      {loading && loadingPosition === 'center' ? (
+        <>
+          {spinner}
+          {loadingText && (
+            <Box component="span" sx={{ ml: 1 }}>
+              {loadingText}
+            </Box>
+          )}
+        </>
+      ) : (
+        content
+      )}
     </MuiButton>
   );
 }

--- a/frontend/src/components/atoms/TertiaryButton.docs.mdx
+++ b/frontend/src/components/atoms/TertiaryButton.docs.mdx
@@ -6,7 +6,7 @@ import { TertiaryButton } from './TertiaryButton';
 
 # TertiaryButton
 
-Botón para acciones de bajo énfasis o enlaces estilo botón.
+Botón para acciones de bajo énfasis o enlaces estilo botón. Soporta estado de carga para procesos que demoran.
 
 <Story id="atoms-tertiarybutton--default" />
 

--- a/frontend/src/components/atoms/TertiaryButton.stories.tsx
+++ b/frontend/src/components/atoms/TertiaryButton.stories.tsx
@@ -15,6 +15,12 @@ const meta: Meta<typeof TertiaryButton> = {
     children: { control: 'text' },
     disabled: { control: 'boolean' },
     href: { control: 'text' },
+    loading: { control: 'boolean' },
+    loadingPosition: {
+      control: 'select',
+      options: ['center', 'start', 'end'],
+    },
+    loadingText: { control: 'text' },
   },
 };
 export default meta;
@@ -29,4 +35,12 @@ export const Disabled: Story = {
 
 export const WithIcon: Story = {
   args: { endIcon: <ArrowForwardIcon /> },
+};
+
+export const Loading: Story = {
+  args: { loading: true },
+};
+
+export const LoadingWithText: Story = {
+  args: { loading: true, loadingText: 'Loading...' },
 };

--- a/frontend/src/components/atoms/TertiaryButton.test.tsx
+++ b/frontend/src/components/atoms/TertiaryButton.test.tsx
@@ -39,4 +39,10 @@ describe('TertiaryButton', () => {
     const link = screen.getByRole('link', { name: /link/i });
     expect(link).toHaveAttribute('href', 'https://example.com');
   });
+
+  it('shows spinner when loading', () => {
+    renderWithTheme(<TertiaryButton loading>Loading</TertiaryButton>);
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
 });

--- a/frontend/src/components/atoms/TertiaryButton.tsx
+++ b/frontend/src/components/atoms/TertiaryButton.tsx
@@ -1,7 +1,25 @@
-import { Button as MuiButton, ButtonProps as MuiButtonProps } from '@mui/material';
-import { PropsWithChildren } from 'react';
+import {
+  Box,
+  CircularProgress,
+  Button as MuiButton,
+  ButtonProps as MuiButtonProps,
+} from '@mui/material';
+import { PropsWithChildren, ReactNode } from 'react';
 
-export type TertiaryButtonProps = MuiButtonProps & PropsWithChildren;
+export interface TertiaryButtonProps extends MuiButtonProps {
+  /**
+   * Muestra un spinner e impide interacción mientras se completa la acción.
+   */
+  loading?: boolean;
+  /**
+   * Posición del spinner cuando `loading` es true.
+   */
+  loadingPosition?: 'start' | 'end' | 'center';
+  /**
+   * Texto opcional cuando el botón está en carga.
+   */
+  loadingText?: ReactNode;
+}
 
 /**
  * Botón terciario para acciones de bajo énfasis o enlaces estilo botón.
@@ -13,16 +31,23 @@ export function TertiaryButton({
   disabled = false,
   startIcon,
   endIcon,
+  loading = false,
+  loadingPosition = 'center',
+  loadingText,
   ...props
 }: PropsWithChildren<TertiaryButtonProps>) {
+  const spinner = <CircularProgress size={20} color="inherit" />;
+  const content = loading && loadingText ? loadingText : children;
+
   return (
     <MuiButton
       variant="text"
       color="primary"
       onClick={onClick}
-      disabled={disabled}
-      startIcon={startIcon}
-      endIcon={endIcon}
+      disabled={disabled || loading}
+      aria-busy={loading || undefined}
+      startIcon={loading && loadingPosition === 'start' ? spinner : startIcon}
+      endIcon={loading && loadingPosition === 'end' ? spinner : endIcon}
       sx={{
         textTransform: 'none',
         '&:hover': {
@@ -32,7 +57,18 @@ export function TertiaryButton({
       }}
       {...props}
     >
-      {children}
+      {loading && loadingPosition === 'center' ? (
+        <>
+          {spinner}
+          {loadingText && (
+            <Box component="span" sx={{ ml: 1 }}>
+              {loadingText}
+            </Box>
+          )}
+        </>
+      ) : (
+        content
+      )}
     </MuiButton>
   );
 }


### PR DESCRIPTION
## Summary
- enhance `SecondaryButton` with loading prop
- enhance `TertiaryButton` with loading prop
- document `PrimaryButton` in Storybook
- update stories for new button states
- cover new cases in unit tests

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685c0b1d1804832b9bd7ca59ee12a099