### PR TITLE
feat(atoms): enhance Alert component

### DIFF
--- a/frontend/src/components/atoms/Alert.docs.mdx
+++ b/frontend/src/components/atoms/Alert.docs.mdx
@@ -8,6 +8,8 @@ import { Alert } from './Alert';
 
 Indicador visual de información, éxito, advertencia o error.
 
+Permite ocultar el icono, elegir un tamaño compacto y definir un tiempo de cierre automático.
+
 <Story id="atoms-alert--info" />
 
 <ArgsTable of={Alert} story="Info" />

--- a/frontend/src/components/atoms/Alert.stories.tsx
+++ b/frontend/src/components/atoms/Alert.stories.tsx
@@ -7,6 +7,7 @@ const meta: Meta<typeof Alert> = {
   args: {
     severity: 'info',
     children: 'Información relevante para el usuario.',
+    size: 'medium',
   },
   argTypes: {
     onClose: { action: 'closed' },
@@ -18,6 +19,12 @@ const meta: Meta<typeof Alert> = {
       control: 'select',
       options: ['standard', 'outlined', 'filled'],
     },
+    size: {
+      control: 'radio',
+      options: ['small', 'medium'],
+    },
+    hideIcon: { control: 'boolean' },
+    autoHideDuration: { control: 'number' },
     title: { control: 'text' },
     children: { control: 'text' },
   },
@@ -52,4 +59,16 @@ export const WithTitle: Story = {
 };
 export const Filled: Story = {
   args: { severity: 'success', variant: 'filled', children: 'Acción completada.' },
+};
+
+export const Small: Story = {
+  args: { size: 'small', children: 'Alerta compacta' },
+};
+
+export const WithoutIcon: Story = {
+  args: { hideIcon: true, children: 'Sin icono' },
+};
+
+export const AutoHide: Story = {
+  args: { onClose: () => {}, autoHideDuration: 3000, children: 'Se cierra solo' },
 };

--- a/frontend/src/components/atoms/Alert.test.tsx
+++ b/frontend/src/components/atoms/Alert.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Alert } from './Alert';
 import { ThemeProvider } from '../../theme';
@@ -49,5 +49,31 @@ describe('Alert', () => {
     );
     expect(screen.getByText('Error:')).toBeInTheDocument();
     expect(screen.getByText('Falló')).toBeInTheDocument();
+  });
+
+  it('hides icon when hideIcon is true', () => {
+    const { container } = renderWithTheme(<Alert hideIcon>Sin icono</Alert>);
+    expect(container.querySelector('.MuiAlert-icon')).toBeNull();
+  });
+
+  it('auto hides after specified duration', () => {
+    jest.useFakeTimers();
+    const handleClose = jest.fn();
+    renderWithTheme(
+      <Alert onClose={handleClose} autoHideDuration={2000}>
+        Desaparece
+      </Alert>,
+    );
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+    expect(handleClose).toHaveBeenCalled();
+    jest.useRealTimers();
+  });
+
+  it('applies small size styles', () => {
+    const { container } = renderWithTheme(<Alert size="small">Pequeña</Alert>);
+    const root = container.firstChild as HTMLElement;
+    expect(root).toHaveStyle('font-size: 0.875rem');
   });
 });

--- a/frontend/src/components/atoms/Alert.tsx
+++ b/frontend/src/components/atoms/Alert.tsx
@@ -1,12 +1,21 @@
 import MuiAlert, { AlertProps as MuiAlertProps } from '@mui/material/Alert';
 import MuiAlertTitle from '@mui/material/AlertTitle';
-import { PropsWithChildren, ReactNode } from 'react';
+import { PropsWithChildren, ReactNode, useEffect } from 'react';
 
 export interface AlertProps extends Omit<MuiAlertProps, 'children'> {
   /** Texto principal de la alerta. Puede usarse en lugar de `children`. */
   message?: ReactNode;
   /** Título opcional mostrado en negrita antes del contenido. */
   title?: ReactNode;
+  /** Oculta el icono de severidad. */
+  hideIcon?: boolean;
+  /** Tamaño del componente. */
+  size?: 'small' | 'medium';
+  /**
+   * Tiempo en milisegundos para cerrar automáticamente la alerta.
+   * Requiere `onClose`.
+   */
+  autoHideDuration?: number;
 }
 
 /**
@@ -18,11 +27,36 @@ export function Alert({
   onClose,
   message,
   title,
+  hideIcon = false,
+  size = 'medium',
+  autoHideDuration,
   children,
   ...props
 }: PropsWithChildren<AlertProps>) {
+  useEffect(() => {
+    if (autoHideDuration && onClose) {
+      const timer = setTimeout(() => {
+        onClose(new Event('timeout') as unknown as React.SyntheticEvent, 'timeout');
+      }, autoHideDuration);
+      return () => clearTimeout(timer);
+    }
+    return undefined;
+  }, [autoHideDuration, onClose]);
+
+  const { sx, ...rest } = props;
+
+  const sizeStyles =
+    size === 'small' ? { py: 0.5, px: 1.5, fontSize: '0.875rem' } : undefined;
+
   return (
-    <MuiAlert severity={severity} variant={variant} onClose={onClose} {...props}>
+    <MuiAlert
+      severity={severity}
+      variant={variant}
+      onClose={onClose}
+      icon={hideIcon ? false : undefined}
+      sx={{ ...sizeStyles, ...sx }}
+      {...rest}
+    >
       {title && <MuiAlertTitle>{title}</MuiAlertTitle>}
       {children ?? message}
     </MuiAlert>


### PR DESCRIPTION
## Summary
- add autoHideDuration, size and hideIcon props
- document new props in Alert docs
- showcase additional Alert stories
- expand Alert unit tests

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685c1496c994832b83ffd7c4ddb2530d