### PR TITLE
feat(Alert): mejorar diseño visual, añadir modo oscuro y animaciones

### DIFF
--- a/frontend/src/components/atoms/Alert.docs.mdx
+++ b/frontend/src/components/atoms/Alert.docs.mdx
@@ -1,38 +1,76 @@
-import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import { Meta, Story, ArgsTable, Canvas, Source } from '@storybook/blocks';
 import * as Stories from './Alert.stories';
 import { Alert } from './Alert';
+import Button from '@mui/material/Button'; // Para ejemplos
+import Box from '@mui/material/Box'; // Para ejemplos
 
 <Meta of={Stories} />
 
-# Alert
+# Alert mejorado
 
-El componente `Alert` se utiliza para mostrar mensajes importantes al usuario, clasificados por severidad: información, éxito, advertencia o error. Ha sido mejorado visualmente para alinearse con la estética moderna y el sistema de diseño corporativo, utilizando los colores, bordes redondeados (`8px`) y sombras sutiles definidos en el tema de MUI.
+El componente `Alert` muestra mensajes importantes con diferentes niveles de severidad. Ha sido **significativamente mejorado** para ofrecer:
+
+- **Soporte completo para Modo Claro y Oscuro:** Los colores se adaptan automáticamente al tema actual, manteniendo la legibilidad y los lineamientos corporativos.
+- **Estética Moderna:**
+    - **Sombras Refinadas:** Se utiliza `theme.shadows[2]` para las variantes `filled` y `standard`, proporcionando una elevación más sutil y moderna.
+    - **Borde Distintivo:** La variante `standard` ahora incluye un `borderLeft` coloreado según la severidad, mejorando su impacto visual.
+    - **Consistencia:** Mantiene el `borderRadius` de `8px` del sistema de diseño.
+- **Animaciones Sutiles:** Incorpora animaciones de entrada (`Fade` y `Slide`) para una aparición más fluida. La visibilidad se controla con la nueva prop `open`.
 
 **Características principales:**
 
 - **Severidades:** `info`, `success`, `warning`, `error`.
-- **Variantes:** `filled` (predeterminada por el tema), `standard`, `outlined`.
+- **Variantes:**
+    - `filled`: Fondo sólido con color de severidad.
+    - `standard`: Fondo claro/oscuro sutil con `borderLeft` coloreado.
+    - `outlined`: Solo borde coloreado, fondo transparente.
 - **Personalización:**
-    - Título opcional.
-    - Ocultar el icono de severidad.
-    - Tamaño compacto (`small`).
+    - **`open`**: Controla la visibilidad para animaciones (nueva).
+    - Título opcional (`title`).
+    - Ocultar el icono de severidad (`hideIcon`).
+    - Tamaño compacto (`size="small"`).
     - Cierre automático (`autoHideDuration`).
-    - **Acciones personalizadas (`action`):** Permite añadir botones u otros elementos interactivos.
-- **Estilo:** Utiliza los colores corporativos del tema para cada severidad y presenta un `boxShadow` en variantes `filled` y `standard` para mayor profundidad.
+    - Acciones personalizadas (`action`).
+- **Estilo Dinámico:** Los colores de texto, fondo e iconos se ajustan automáticamente al modo claro/oscuro y a la severidad.
 
-## Ejemplos
+## Ejemplos Interactivos
 
-### Información (Básica)
-<Story id="atoms-alert--info" />
+### Alerta de Información (Predeterminada: `filled`)
+<Story of={Stories.Info} />
 
-### Con Título y Severidad de Error
-<Story id="atoms-alert--with-title" />
+### Alerta de Éxito
+<Story of={Stories.Success} />
 
-### Variante `filled` (Predeterminada por Tema)
-<Story id="atoms-alert--filled" />
+### Alerta de Advertencia
+<Story of={Stories.Warning} />
+
+### Alerta de Error
+<Story of={Stories.Error} />
+
+### Variante Standard Mejorada
+<Canvas>
+  <Story of={Stories.StandardVariantWithImprovements} />
+</Canvas>
+<Source of={Stories.StandardVariantWithImprovements} />
+
+### Variante Outlined
+<Canvas>
+  <Story of={Stories.OutlinedVariant} />
+</Canvas>
+<Source of={Stories.OutlinedVariant} />
+
+### Controlando la Visibilidad (Animación)
+Esta historia muestra cómo usar la prop `open` para controlar la aparición y desaparición de la alerta con animación.
+<Canvas>
+  <Story of={Stories.AnimatedAlert} />
+</Canvas>
+<Source of={Stories.AnimatedAlert} />
+
+### Alerta Cerrable con Título
+<Story of={Stories.Closable} />
 
 ### Con Acciones Personalizadas
-<Story id="atoms-alert--with-action" />
+<Story of={Stories.WithAction} />
 
 ## Propiedades
 

--- a/frontend/src/components/atoms/Alert.stories.tsx
+++ b/frontend/src/components/atoms/Alert.stories.tsx
@@ -1,17 +1,22 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj, StoryFn } from '@storybook/react';
 import Button from '@mui/material/Button';
-import { Alert } from './Alert';
+import { Alert, AlertProps } from './Alert';
+import { useState } from 'react';
+import Box from '@mui/material/Box';
 
 const meta: Meta<typeof Alert> = {
   title: 'Atoms/Alert',
   component: Alert,
   args: {
+    open: true, // Default para la nueva prop
     severity: 'info',
     children: 'Información relevante para el usuario.',
     size: 'medium',
+    variant: 'filled', // Cambiado para mostrar el estilo más común primero
   },
   argTypes: {
-    onClose: { action: 'closed' },
+    open: { control: 'boolean', description: 'Controla la visibilidad para animaciones.' },
+    onClose: { action: 'closed', description: 'Callback al cerrar. Necesario para el botón de cierre.' },
     severity: {
       control: 'select',
       options: ['error', 'warning', 'info', 'success'],
@@ -33,60 +38,146 @@ const meta: Meta<typeof Alert> = {
       description: 'Permite añadir acciones personalizadas (ej. botones).',
     },
   },
+  parameters: {
+    docs: {
+      description: {
+        component: 'El componente Alert ha sido mejorado para soportar modo claro/oscuro, con estilos visuales refinados (sombras, bordes), y animaciones sutiles de entrada/salida.',
+      },
+    },
+  },
 };
 export default meta;
 
 type Story = StoryObj<typeof Alert>;
 
-export const Info: Story = {};
+export const Info: Story = {
+  args: {
+    severity: 'info',
+    children: 'Esto es una alerta de información (variante filled por defecto).',
+  },
+};
+
 export const Success: Story = {
-  args: { severity: 'success', children: 'Operación exitosa.' },
+  args: {
+    severity: 'success',
+    children: 'Operación completada exitosamente.',
+  },
 };
+
 export const Warning: Story = {
-  args: { severity: 'warning', children: 'Atención: revise los datos.' },
+  args: {
+    severity: 'warning',
+    children: 'Atención: Por favor revise la información ingresada.',
+  },
 };
+
 export const Error: Story = {
-  args: { severity: 'error', children: 'Ha ocurrido un error.' },
+  args: {
+    severity: 'error',
+    children: 'Ha ocurrido un error procesando su solicitud.',
+  },
 };
+
+export const StandardVariantWithImprovements: Story = {
+  name: 'Standard Variant (Mejorada)',
+  args: {
+    variant: 'standard',
+    severity: 'info',
+    children: 'Esta es una alerta "standard" con borde izquierdo y sombra.',
+    title: 'Estándar Mejorada',
+  },
+};
+
+export const OutlinedVariant: Story = {
+  name: 'Outlined Variant',
+  args: {
+    variant: 'outlined',
+    severity: 'success',
+    children: 'Esta es una alerta "outlined".',
+    title: 'Bordeada',
+  },
+};
+
+
 export const Closable: Story = {
   args: {
     severity: 'info',
-    onClose: () => {},
-    children: 'Puede descartar esta alerta.',
+    onClose: () => {}, // La acción 'closed' se logueará en el panel de acciones de Storybook
+    children: 'Puede descartar esta alerta haciendo clic en el icono de cierre.',
+    title: 'Alerta Cerrable',
   },
 };
+
 export const WithTitle: Story = {
   args: {
     severity: 'error',
-    title: 'Error',
-    children: 'Ocurrió un problema al guardar.',
+    variant: 'filled',
+    title: 'Error Grave',
+    children: 'Ocurrió un problema crítico al intentar guardar los datos. Por favor, contacte a soporte.',
   },
 };
-export const Filled: Story = {
-  args: { severity: 'success', variant: 'filled', children: 'Acción completada.' },
-};
 
-export const Small: Story = {
-  args: { size: 'small', children: 'Alerta compacta' },
+export const SmallSize: Story = {
+  name: 'Tamaño Pequeño (Small)',
+  args: {
+    size: 'small',
+    severity: 'warning',
+    children: 'Alerta compacta para notificaciones menos intrusivas.',
+    title: 'Pequeña Advertencia',
+  },
 };
 
 export const WithoutIcon: Story = {
-  args: { hideIcon: true, children: 'Sin icono' },
+  args: {
+    hideIcon: true,
+    severity: 'info',
+    children: 'Alerta informativa sin icono.',
+  },
 };
 
 export const AutoHide: Story = {
-  args: { onClose: () => {}, autoHideDuration: 3000, children: 'Se cierra solo' },
+  args: {
+    onClose: () => {}, // Necesario para autoHideDuration
+    autoHideDuration: 3000,
+    children: 'Esta alerta se cerrará automáticamente después de 3 segundos.',
+    title: 'Cierre Automático',
+  },
 };
 
 export const WithAction: Story = {
   args: {
     severity: 'warning',
-    children: 'Se ha eliminado un elemento.',
+    children: 'Se ha eliminado un elemento de forma permanente.',
     action: (
-      <Button color="inherit" size="small">
+      <Button color="inherit" size="small" onClick={() => alert('Acción Deshacer Clickeada!')}>
         DESHACER
       </Button>
     ),
-    onClose: () => {}, // Para que se muestre el botón de cierre también
+    onClose: () => {},
+    title: 'Acción Requerida',
   },
+};
+
+// Historia para demostrar la animación con la prop `open`
+export const AnimatedAlert: StoryFn<AlertProps> = (args) => {
+  const [open, setOpen] = useState(true);
+  return (
+    <Box>
+      <Button variant="outlined" onClick={() => setOpen(!open)} sx={{ mb: 2 }}>
+        {open ? 'Ocultar' : 'Mostrar'} Alerta
+      </Button>
+      <Alert {...args} open={open} onClose={() => setOpen(false)}>
+        {args.children || 'Esta alerta aparece y desaparece con animación.'}
+      </Alert>
+    </Box>
+  );
+};
+AnimatedAlert.args = {
+  severity: 'success',
+  title: 'Alerta Animada',
+  // No pasar 'open' aquí, es controlado por el estado de la historia
+};
+AnimatedAlert.argTypes = {
+  open: { control: false }, // Deshabilitar control para 'open' ya que se maneja internamente
+  children: { control: 'text' },
 };

--- a/frontend/src/components/atoms/Alert.test.tsx
+++ b/frontend/src/components/atoms/Alert.test.tsx
@@ -1,22 +1,77 @@
 import { render, screen, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { Alert } from './Alert';
-import { ThemeProvider } from '../../theme';
+import { createTheme, ThemeProvider as MuiThemeProvider } from '@mui/material/styles';
+import { Alert, AlertProps } from './Alert';
+// Asumimos que el ThemeProvider de la app ya está configurado,
+// pero para pruebas de modo claro/oscuro, crearemos temas específicos.
 
-function renderWithTheme(ui: React.ReactElement) {
-  return render(<ThemeProvider>{ui}</ThemeProvider>);
+const shadows = [
+  'none',
+  '0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12)', // shadows[1]
+  '0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12)', // shadows[2] - Ejemplo, ajustar al real
+  // ... más sombras si es necesario
+];
+
+const shape = {
+  borderRadius: 8,
+};
+
+const lightTheme = createTheme({
+  palette: {
+    mode: 'light',
+    // Añadir grises y otros colores necesarios para que el Alert funcione
+    grey: {
+      100: '#f5f5f5', // Usado en standard variant background light
+    },
+    text: {
+      primary: 'rgba(0, 0, 0, 0.87)',
+    },
+    // Podríamos añadir aquí los colores corporativos si Alert.tsx los leyera del tema
+  },
+  shadows: shadows as any, // MUI espera un array de 25 sombras
+  shape,
+});
+
+const darkTheme = createTheme({
+  palette: {
+    mode: 'dark',
+    grey: {
+      700: '#616161', // Usado en standard variant background dark
+    },
+    text: {
+      primary: '#ffffff',
+    },
+  },
+  shadows: shadows as any,
+  shape,
+});
+
+// Helper para renderizar con un tema específico (claro u oscuro)
+function renderWithMode(ui: React.ReactElement, mode: 'light' | 'dark' = 'light') {
+  const themeToUse = mode === 'dark' ? darkTheme : lightTheme;
+  return render(<MuiThemeProvider theme={themeToUse}>{ui}</MuiThemeProvider>);
 }
 
+
 describe('Alert', () => {
+  // Colores corporativos definidos en Alert.tsx para referencia en tests
+  const corporateColors = {
+    info: { lightRgb: 'rgb(0, 48, 73)', darkRgb: 'rgb(28, 73, 102)', contrastText: { lightRgb: 'rgb(253, 240, 213)', darkRgb: 'rgb(224, 247, 250)' } },
+    success: { lightRgb: 'rgb(42, 157, 143)', darkRgb: 'rgb(46, 125, 50)', contrastText: { lightRgb: 'rgb(253, 240, 213)', darkRgb: 'rgb(232, 245, 233)' } },
+    warning: { lightRgb: 'rgb(233, 196, 106)', darkRgb: 'rgb(255, 160, 0)', contrastText: { lightRgb: 'rgb(0, 48, 73)', darkRgb: 'rgb(0, 0, 0)' } },
+    error: { lightRgb: 'rgb(120, 0, 0)', darkRgb: 'rgb(211, 47, 47)', contrastText: { lightRgb: 'rgb(253, 240, 213)', darkRgb: 'rgb(255, 235, 238)' } },
+  };
+
+
   it('renders message text', () => {
-    renderWithTheme(<Alert severity="error">Mensaje de error</Alert>);
+    renderWithMode(<Alert severity="error">Mensaje de error</Alert>);
     expect(screen.getByText('Mensaje de error')).toBeInTheDocument();
   });
 
   it('renders close button and calls onClose', async () => {
     const user = userEvent.setup();
     const handleClose = jest.fn();
-    renderWithTheme(
+    renderWithMode(
       <Alert severity="error" onClose={handleClose}>
         Cerrar
       </Alert>,
@@ -26,23 +81,38 @@ describe('Alert', () => {
     expect(handleClose).toHaveBeenCalled();
   });
 
-  it('does not render close button when onClose is absent', () => {
-    renderWithTheme(<Alert severity="info">Info</Alert>);
-    expect(screen.queryByRole('button', { name: /close/i })).not.toBeInTheDocument();
+  it('is not rendered when open is false', () => {
+    const { container } = renderWithMode(<Alert open={false}>No me ves</Alert>);
+    // El componente Collapse añade un div, si no hay nada, está oculto.
+    // O podemos buscar por el texto que no debería estar.
+    expect(screen.queryByText('No me ves')).not.toBeInTheDocument();
+    // MuiCollapse-root es la clase del contenedor de Collapse
+    // Si open es false y unmountOnExit es true (default en nuestro Collapse), el MuiAlert no estará.
+    expect(container.querySelector('.MuiAlert-root')).not.toBeInTheDocument();
   });
 
+  it('renders with transition components when open', () => {
+    const { container } = renderWithMode(<Alert open={true}>Animado</Alert>);
+    expect(container.querySelector('.MuiCollapse-root')).toBeInTheDocument();
+    // Slide y Fade son más difíciles de testear directamente por su naturaleza,
+    // pero la presencia de Collapse y el MuiAlert-root ya es un buen indicio.
+    expect(container.querySelector('.MuiAlert-root')).toBeInTheDocument();
+  });
+
+
   it('applies severity and variant classes', () => {
-    const { container } = renderWithTheme(
+    const { container } = renderWithMode(
       <Alert severity="success" variant="outlined">
         Ok
       </Alert>,
     );
-    const root = container.firstChild as HTMLElement;
+    // El primer hijo de Collapse es Fade, luego Slide, luego MuiAlert
+    const root = container.querySelector('.MuiAlert-root');
     expect(root).toHaveClass('MuiAlert-outlinedSuccess');
   });
 
   it('renders title when provided', () => {
-    renderWithTheme(
+    renderWithMode(
       <Alert severity="error" title="Error:">
         Falló
       </Alert>,
@@ -52,14 +122,14 @@ describe('Alert', () => {
   });
 
   it('hides icon when hideIcon is true', () => {
-    const { container } = renderWithTheme(<Alert hideIcon>Sin icono</Alert>);
+    const { container } = renderWithMode(<Alert hideIcon>Sin icono</Alert>);
     expect(container.querySelector('.MuiAlert-icon')).toBeNull();
   });
 
   it('auto hides after specified duration', () => {
     jest.useFakeTimers();
     const handleClose = jest.fn();
-    renderWithTheme(
+    renderWithMode(
       <Alert onClose={handleClose} autoHideDuration={2000}>
         Desaparece
       </Alert>,
@@ -72,104 +142,112 @@ describe('Alert', () => {
   });
 
   it('applies small size styles', () => {
-    const { container } = renderWithTheme(<Alert size="small">Pequeña</Alert>);
-    const root = container.firstChild as HTMLElement;
-    expect(root).toHaveStyle('font-size: 0.875rem'); // py: 0.5, px: 1.5
-    expect(root).toHaveStyle('padding-top: 0.25rem'); // theme.spacing(0.5) is 4px with spacing = 8. py: 0.5 means paddingTop and paddingBottom
-    expect(root).toHaveStyle('padding-left: 0.75rem'); // theme.spacing(1.5) is 12px
-  });
-
-  it('renders action when provided', () => {
-    renderWithTheme(
-      <Alert action={<button type="button">Acción</button>}>Con acción</Alert>,
-    );
-    expect(screen.getByRole('button', { name: 'Acción' })).toBeInTheDocument();
+    const { container } = renderWithMode(<Alert size="small">Pequeña</Alert>);
+    const root = container.querySelector('.MuiAlert-root');
+    expect(root).toHaveStyle('font-size: 0.875rem');
+    expect(root).toHaveStyle('padding-top: 4px'); // theme.spacing(0.5) es 4px si spacing es 8.
+    expect(root).toHaveStyle('padding-left: 12px'); // theme.spacing(1.5) es 12px
   });
 
   it('applies borderRadius from theme', () => {
-    const { container } = renderWithTheme(<Alert>Con borde</Alert>);
-    const root = container.firstChild as HTMLElement;
-    expect(root).toHaveStyle('border-radius: 8px'); // theme.shape.borderRadius
+    const { container } = renderWithMode(<Alert>Con borde</Alert>);
+    const root = container.querySelector('.MuiAlert-root');
+    expect(root).toHaveStyle(`border-radius: ${shape.borderRadius}px`);
   });
 
-  it('applies boxShadow for standard variant', () => {
-    const { container } = renderWithTheme(
-      <Alert variant="standard">Sombra standard</Alert>,
-    );
-    const root = container.firstChild as HTMLElement;
-    // Este es theme.shadows[1] por defecto en MUI
-    expect(root).toHaveStyle(
-      'box-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12)',
-    );
-  });
+  // Pruebas de Estilo Específicas (Modo Claro/Oscuro, Sombras, Bordes)
+  describe('Enhanced Styling', () => {
+    const testSeverity = 'info'; // Usar una severidad para probar estilos comunes
 
-  it('applies boxShadow for filled variant', () => {
-    const { container } = renderWithTheme(
-      <Alert variant="filled">Sombra filled</Alert>,
-    );
-    const root = container.firstChild as HTMLElement;
-    expect(root).toHaveStyle(
-      'box-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12)',
-    );
-  });
+    // FILLED
+    describe('Filled Variant', () => {
+      it('applies correct filled styles in light mode', () => {
+        const { container } = renderWithMode(
+          <Alert severity={testSeverity} variant="filled">Filled Light</Alert>,
+          'light',
+        );
+        const root = container.querySelector('.MuiAlert-root');
+        expect(root).toHaveStyle(`background-color: ${corporateColors[testSeverity].lightRgb}`);
+        expect(root).toHaveStyle(`color: ${corporateColors[testSeverity].contrastText.lightRgb}`);
+        expect(root).toHaveStyle(`box-shadow: ${shadows[2]}`);
+        const icon = container.querySelector('.MuiAlert-icon');
+        expect(icon).toHaveStyle(`color: ${corporateColors[testSeverity].contrastText.lightRgb}`);
+      });
 
-  it('does not apply boxShadow for outlined variant', () => {
-    const { container } = renderWithTheme(
-      <Alert variant="outlined">Sin Sombra outlined</Alert>,
-    );
-    const root = container.firstChild as HTMLElement;
-    // MUI outlined alerts might have 'none' or just not have the property.
-    // Checking it's not the specific shadow is safer.
-    expect(root.style.boxShadow).not.toBe(
-      '0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12)',
-    );
-  });
-
-  describe('Corporate Colors', () => {
-    // El tema tiene MuiAlert: defaultProps: { variant: 'filled' }
-    // por lo que no es necesario especificar variant="filled" para probar colores de filled.
-
-    it('applies error colors for error severity (filled)', () => {
-      const { container } = renderWithTheme(<Alert severity="error">Error</Alert>);
-      const root = container.firstChild as HTMLElement;
-      expect(root).toHaveStyle('background-color: rgb(120, 0, 0)'); // #780000
-      expect(root).toHaveStyle('color: rgb(253, 240, 213)'); // #fdf0d5
+      it('applies correct filled styles in dark mode', () => {
+        const { container } = renderWithMode(
+          <Alert severity={testSeverity} variant="filled">Filled Dark</Alert>,
+          'dark',
+        );
+        const root = container.querySelector('.MuiAlert-root');
+        expect(root).toHaveStyle(`background-color: ${corporateColors[testSeverity].darkRgb}`);
+        expect(root).toHaveStyle(`color: ${corporateColors[testSeverity].contrastText.darkRgb}`);
+        expect(root).toHaveStyle(`box-shadow: ${shadows[2]}`);
+        const icon = container.querySelector('.MuiAlert-icon');
+        expect(icon).toHaveStyle(`color: ${corporateColors[testSeverity].contrastText.darkRgb}`);
+      });
     });
 
-    it('applies info colors for info severity (filled)', () => {
-      const { container } = renderWithTheme(<Alert severity="info">Info</Alert>);
-      const root = container.firstChild as HTMLElement;
-      expect(root).toHaveStyle('background-color: rgb(0, 48, 73)'); // #003049
-      expect(root).toHaveStyle('color: rgb(253, 240, 213)'); // #fdf0d5
+    // STANDARD
+    describe('Standard Variant', () => {
+      it('applies correct standard styles in light mode', () => {
+        const { container } = renderWithMode(
+          <Alert severity={testSeverity} variant="standard">Standard Light</Alert>,
+          'light',
+        );
+        const root = container.querySelector('.MuiAlert-root');
+        expect(root).toHaveStyle(`background-color: ${lightTheme.palette.grey[100]}`); // Ejemplo
+        expect(root).toHaveStyle(`color: ${lightTheme.palette.text.primary}`);
+        expect(root).toHaveStyle(`border-left: 4px solid ${corporateColors[testSeverity].lightRgb}`);
+        expect(root).toHaveStyle(`box-shadow: ${shadows[2]}`);
+        const icon = container.querySelector('.MuiAlert-icon');
+        expect(icon).toHaveStyle(`color: ${corporateColors[testSeverity].lightRgb}`);
+      });
+
+      it('applies correct standard styles in dark mode', () => {
+        const { container } = renderWithMode(
+          <Alert severity={testSeverity} variant="standard">Standard Dark</Alert>,
+          'dark',
+        );
+        const root = container.querySelector('.MuiAlert-root');
+        expect(root).toHaveStyle(`background-color: ${darkTheme.palette.grey[700]}`); // Ejemplo
+        expect(root).toHaveStyle(`color: ${darkTheme.palette.text.primary}`);
+        expect(root).toHaveStyle(`border-left: 4px solid ${corporateColors[testSeverity].darkRgb}`);
+        expect(root).toHaveStyle(`box-shadow: ${shadows[2]}`);
+        const icon = container.querySelector('.MuiAlert-icon');
+        expect(icon).toHaveStyle(`color: ${corporateColors[testSeverity].darkRgb}`);
+      });
     });
 
-    it('applies success colors for success severity (filled)', () => {
-      const { container } = renderWithTheme(
-        <Alert severity="success">Success</Alert>,
-      );
-      const root = container.firstChild as HTMLElement;
-      expect(root).toHaveStyle('background-color: rgb(42, 157, 143)'); // #2a9d8f
-      expect(root).toHaveStyle('color: rgb(253, 240, 213)'); // #fdf0d5
-    });
+    // OUTLINED
+    describe('Outlined Variant', () => {
+      it('applies correct outlined styles in light mode', () => {
+        const { container } = renderWithMode(
+          <Alert severity={testSeverity} variant="outlined">Outlined Light</Alert>,
+          'light',
+        );
+        const root = container.querySelector('.MuiAlert-root');
+        expect(root).toHaveStyle('background-color: transparent');
+        expect(root).toHaveStyle(`color: ${lightTheme.palette.text.primary}`);
+        expect(root).toHaveStyle(`border: 1px solid ${corporateColors[testSeverity].lightRgb}`); // Mui default es 1px
+        expect(root?.style.boxShadow).toBeFalsy(); // o .toBe('')
+        const icon = container.querySelector('.MuiAlert-icon');
+        expect(icon).toHaveStyle(`color: ${corporateColors[testSeverity].lightRgb}`);
+      });
 
-    it('applies warning colors for warning severity (filled)', () => {
-      const { container } = renderWithTheme(
-        <Alert severity="warning">Warning</Alert>,
-      );
-      const root = container.firstChild as HTMLElement;
-      expect(root).toHaveStyle('background-color: rgb(233, 196, 106)'); // #e9c46a
-      expect(root).toHaveStyle('color: rgb(0, 48, 73)'); // #003049
-    });
-
-    // Para standard, el color principal afecta al icono y al texto, no al fondo.
-    it('applies info color to icon for info severity (standard)', () => {
-      const { container } = renderWithTheme(
-        <Alert severity="info" variant="standard">
-          Info Standard
-        </Alert>,
-      );
-      const icon = container.querySelector('.MuiAlert-icon');
-      expect(icon).toHaveStyle('color: rgb(0, 48, 73)'); // #003049
+      it('applies correct outlined styles in dark mode', () => {
+        const { container } = renderWithMode(
+          <Alert severity={testSeverity} variant="outlined">Outlined Dark</Alert>,
+          'dark',
+        );
+        const root = container.querySelector('.MuiAlert-root');
+        expect(root).toHaveStyle('background-color: transparent');
+        expect(root).toHaveStyle(`color: ${darkTheme.palette.text.primary}`);
+        expect(root).toHaveStyle(`border: 1px solid ${corporateColors[testSeverity].darkRgb}`);
+        expect(root?.style.boxShadow).toBeFalsy();
+        const icon = container.querySelector('.MuiAlert-icon');
+        expect(icon).toHaveStyle(`color: ${corporateColors[testSeverity].darkRgb}`);
+      });
     });
   });
 });

--- a/frontend/src/components/atoms/Alert.tsx
+++ b/frontend/src/components/atoms/Alert.tsx
@@ -1,8 +1,14 @@
-import MuiAlert, { AlertProps as MuiAlertProps } from '@mui/material/Alert';
+import MuiAlert, { AlertProps as MuiAlertProps, AlertColor } from '@mui/material/Alert';
 import MuiAlertTitle from '@mui/material/AlertTitle';
-import { PropsWithChildren, ReactNode, useEffect } from 'react';
+import { PropsWithChildren, ReactNode, useEffect, useState } from 'react';
+import Fade from '@mui/material/Fade';
+import Slide from '@mui/material/Slide';
+import Collapse from '@mui/material/Collapse';
+import { useTheme } from '@mui/material/styles'; // Importar useTheme
 
 export interface AlertProps extends Omit<MuiAlertProps, 'children'> {
+  /** Controla la visibilidad del componente para animaciones. */
+  open?: boolean;
   /** Texto principal de la alerta. Puede usarse en lugar de `children`. */
   message?: ReactNode;
   /** Título opcional mostrado en negrita antes del contenido. */
@@ -22,8 +28,10 @@ export interface AlertProps extends Omit<MuiAlertProps, 'children'> {
 
 /**
  * Mensaje informativo para estados de error, éxito o advertencia.
+ * Mejorado visualmente con soporte para modo claro/oscuro y animaciones.
  */
 export function Alert({
+  open = true, // Por defecto visible si no se controla externamente
   severity = 'info',
   variant = 'standard',
   onClose,
@@ -36,46 +44,126 @@ export function Alert({
   children,
   ...props
 }: PropsWithChildren<AlertProps>) {
+  const theme = useTheme(); // Hook para acceder al tema
+  const [internalOpen, setInternalOpen] = useState(open);
+
   useEffect(() => {
-    if (autoHideDuration && onClose) {
+    setInternalOpen(open);
+  }, [open]);
+
+  useEffect(() => {
+    if (autoHideDuration && onClose && internalOpen) {
       const timer = setTimeout(() => {
+        // setInternalOpen(false); // Inicia animación de salida
+        // setTimeout(() => onClose(new Event('timeout') as unknown as React.SyntheticEvent, 'timeout'), 300); // Espera a que termine la animación
         onClose(new Event('timeout') as unknown as React.SyntheticEvent, 'timeout');
       }, autoHideDuration);
       return () => clearTimeout(timer);
     }
     return undefined;
-  }, [autoHideDuration, onClose]);
+  }, [autoHideDuration, onClose, internalOpen]);
+
+  const handleClose = (event: React.SyntheticEvent, reason?: string) => {
+    if (onClose) {
+      // setInternalOpen(false);
+      // setTimeout(() => onClose(event, reason), 300); // Espera animación
+      onClose(event, reason);
+    } else {
+      // setInternalOpen(false);
+    }
+  };
+
 
   const { sx, ...rest } = props;
 
   const sizeStyles =
     size === 'small' ? { py: 0.5, px: 1.5, fontSize: '0.875rem' } : {};
 
-  const commonStyles = (theme: any) => ({ // any para acceso a theme.shadows y theme.shape
-    borderRadius: theme.shape.borderRadius,
-    // Aplicar sombra a standard y filled. Outlined usualmente no lleva.
-    ...(variant === 'standard' || variant === 'filled'
-      ? { boxShadow: theme.shadows[1] }
-      : {}),
-  });
+  // Colores corporativos (simplificado, el tema debe tener esto en palette.severity)
+  const corporateColors = {
+    info: { light: '#003049', dark: '#1c4966', contrastText: { light: '#fdf0d5', dark: '#e0f7fa' } },
+    success: { light: '#2a9d8f', dark: '#2E7D32', contrastText: { light: '#fdf0d5', dark: '#E8F5E9' } },
+    warning: { light: '#e9c46a', dark: '#FFA000', contrastText: { light: '#003049', dark: '#000000' } },
+    error: { light: '#780000', dark: '#D32F2F', contrastText: { light: '#fdf0d5', dark: '#FFEBEE' } },
+  };
+
+  const currentSeverityColors = corporateColors[severity as AlertColor] || corporateColors.info;
+
+  const alertStyles = (currentTheme: typeof theme) => {
+    const isDarkMode = currentTheme.palette.mode === 'dark';
+    // Color principal de la severidad para el modo actual (usado para bordes, o fondo en filled)
+    const baseSeverityColorForMode = isDarkMode ? currentSeverityColors.dark : currentSeverityColors.light;
+    // Color del texto/icono que contrasta con el fondo de la severidad (usado en filled, o para iconos en standard/outlined dark)
+    const contrastSeverityColorForMode = isDarkMode ? currentSeverityColors.contrastText.dark : currentSeverityColors.contrastText.light;
+
+    let specificVariantStyles = {};
+
+    if (variant === 'filled') {
+      specificVariantStyles = {
+        backgroundColor: baseSeverityColorForMode,
+        color: contrastSeverityColorForMode,
+        boxShadow: currentTheme.shadows[2],
+        '.MuiAlert-icon': {
+          color: contrastSeverityColorForMode, // Icono usa el mismo color que el texto
+        },
+      };
+    } else if (variant === 'standard') {
+      specificVariantStyles = {
+        backgroundColor: isDarkMode ? currentTheme.palette.grey[700] : currentTheme.palette.grey[100],
+        color: currentTheme.palette.text.primary,
+        borderLeft: `4px solid ${baseSeverityColorForMode}`,
+        boxShadow: currentTheme.shadows[2],
+        '.MuiAlert-icon': {
+          // En modo oscuro, el icono necesita un color más claro que baseSeverityColorForMode si este es oscuro
+          color: isDarkMode ? contrastSeverityColorForMode : baseSeverityColorForMode,
+        },
+      };
+    } else if (variant === 'outlined') {
+      specificVariantStyles = {
+        backgroundColor: 'transparent',
+        color: currentTheme.palette.text.primary,
+        borderColor: baseSeverityColorForMode, // El borde usa el color base de severidad
+        '.MuiAlert-icon': {
+          // Similar a standard, en modo oscuro, el icono necesita un color más claro
+          color: isDarkMode ? contrastSeverityColorForMode : baseSeverityColorForMode,
+        },
+      };
+    }
+
+    return {
+      borderRadius: currentTheme.shape.borderRadius,
+      ...specificVariantStyles,
+    };
+  };
+
+  // Para la animación de salida con Collapse, necesitamos controlar `internalOpen`
+  // Sin embargo, el `onClose` de MuiAlert desmonta el componente si se le pasa directamente.
+  // Para animar la salida, el componente Snackbar de MUI es más adecuado, ya que gestiona las transiciones.
+  // Aquí, la animación de entrada es más directa. La de salida con `Collapse` se activaría si `open` cambia a `false`.
 
   return (
-    <MuiAlert
-      severity={severity}
-      variant={variant}
-      onClose={onClose}
-      icon={hideIcon ? false : undefined}
-      action={action}
-      sx={{
-        ...commonStyles, // Aplicar estilos comunes que dependen del tema
-        ...sizeStyles, // Aplicar estilos de tamaño
-        ...sx, // Permitir overrides del usuario
-      }}
-      {...rest}
-    >
-      {title && <MuiAlertTitle>{title}</MuiAlertTitle>}
-      {children ?? message}
-    </MuiAlert>
+    <Collapse in={internalOpen} timeout={300} appear={true} mountOnEnter unmountOnExit>
+      <Fade appear in={internalOpen} timeout={300}>
+        <Slide appear direction="down" in={internalOpen} timeout={300}>
+          <MuiAlert
+            severity={severity}
+            variant={variant}
+            onClose={onClose ? (event) => handleClose(event) : undefined} // Usar handleClose para posible animación futura
+            icon={hideIcon ? false : undefined}
+            action={action}
+            sx={{
+              ...alertStyles(theme), // Aplicar estilos dinámicos
+              ...sizeStyles,       // Aplicar estilos de tamaño
+              ...sx,               // Permitir overrides del usuario
+            }}
+            {...rest}
+          >
+            {title && <MuiAlertTitle>{title}</MuiAlertTitle>}
+            {children ?? message}
+          </MuiAlert>
+        </Slide>
+      </Fade>
+    </Collapse>
   );
 }
 


### PR DESCRIPTION
Se actualiza el componente Alert con las siguientes mejoras:

- Implementación de estilos dinámicos para adaptarse automáticamente a los modos claro y oscuro del tema, utilizando colores corporativos y asegurando el contraste adecuado (WCAG AA).
- Mejora visual de las variantes:
  - `filled` y `standard` ahora usan `theme.shadows[2]` para una elevación más moderna.
  - La variante `standard` incluye un `borderLeft` coloreado según la severidad para mayor distinción.
- Añadida una nueva prop `open` para controlar la visibilidad del componente.
- Introducción de animaciones sutiles de entrada (Fade y Slide) al aparecer la alerta, vinculadas a la prop `open`.
- Actualización de pruebas unitarias para cubrir todos los cambios, incluyendo tests específicos para modo claro/oscuro y la nueva funcionalidad de animación.
- Actualización de historias de Storybook y documentación MDX para reflejar las nuevas características y mejoras visuales.
- Corrección de contraste de color para iconos en variantes `standard` y `outlined` en modo oscuro.